### PR TITLE
refactor(cookie): fix alias binding of `SameSite::Empty` to `None`

### DIFF
--- a/lib/wreq_ruby/cookie.rb
+++ b/lib/wreq_ruby/cookie.rb
@@ -8,8 +8,8 @@ unless defined?(:Wreq)
       Strict = nil
       # Strict same-site policy.
       Lax = nil
-      # Empty/None same-site policy.
-      Empty = nil
+      # None same-site policy.
+      None = nil
     end
 
     # A single HTTP cookie.

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -19,9 +19,9 @@ define_ruby_enum!(
     SameSite,
     "Wreq::SameSite",
     cookie::SameSite,
-    (Strict, Strict),
-    (Lax, Lax),
-    (Empty, None),
+    Strict,
+    Lax,
+    None,
 );
 
 /// A single HTTP cookie.
@@ -262,7 +262,7 @@ pub fn include(ruby: &Ruby, gem_module: &RModule) -> Result<(), Error> {
     let same_site_class = gem_module.define_class("SameSite", ruby.class_object())?;
     same_site_class.const_set("Strict", SameSite::Strict)?;
     same_site_class.const_set("Lax", SameSite::Lax)?;
-    same_site_class.const_set("Empty", SameSite::Empty)?;
+    same_site_class.const_set("None", SameSite::None)?;
 
     // Cookie class
     let cookie_class = gem_module.define_class("Cookie", ruby.class_object())?;


### PR DESCRIPTION
Ruby does not have a None type like Python.
Therefore, creating an alias that maps SameSite::Empty to None is unnecessary and may even cause confusion, since Ruby conventions typically use nil to represent the absence of a value.
To keep the API consistent with Ruby’s type system and avoid implying Python-style semantics, the alias has been removed / corrected accordingly.
