### PR TITLE
ci: add Ruby 3.4 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ on:
       - 'benchmark/**'
       - 'examples/**'
       - '*.md'
-      - '.github/**'
-      - 'README.md'
   workflow_dispatch:
 
 env:
@@ -48,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: ['3.2', '3.3']
+        ruby: ['3.2', '3.3', '3.4']
     
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add Ruby 3.4 to CI test matrix (released December 2024)
- Remove `.github/**` from paths-ignore so workflow changes trigger CI
- Remove redundant `README.md` exclusion (already covered by `*.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)