### PR TITLE
chore(rake): add dev tasks and improve cross-platform config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,71 +3,83 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 require "rb_sys/extensiontask"
-require "standard/rake"
 
-GEMSPEC = Gem::Specification.load("wreq.gemspec")
+begin
+  require "standard/rake"
+rescue LoadError
+  # standard gem not available in cross-compilation environment
+end
+
+GEMSPEC = Gem::Specification.load("wreq.gemspec") || abort("Could not load wreq.gemspec")
 CRATE_PACKAGE_NAME = "wreq-ruby"
 
 RbSys::ExtensionTask.new(CRATE_PACKAGE_NAME, GEMSPEC) do |ext|
   ext.name = "wreq_ruby"
   ext.ext_dir = "."
   ext.lib_dir = "lib/wreq_ruby"
-
   ext.cross_compile = true
   ext.cross_platform = %w[
     x86_64-linux
-    arm64-linux
+    aarch64-linux
     arm64-darwin
-    arm64-darwin23
   ]
 
-  # Override Ruby version requirement for native gems
-  # This prevents automatic constraint to the build Ruby version (e.g., >= 3.3, < 3.4.dev)
-  ext.cross_compiling do |gem_spec|
-    # keep in sync with wreq.gemspec
-    gem_spec.required_ruby_version = ">= 3.2", "< 3.5.dev"
+  # Override Ruby version for native gems (keep in sync with wreq.gemspec)
+  ext.cross_compiling do |spec|
+    spec.required_ruby_version = ">= 3.2", "< 3.5.dev"
   end
 end
 
-Rake::Task[:test].prerequisites << :compile
-
-Rake::TestTask.new do |t|
+Rake::TestTask.new(:ruby_test) do |t|
   t.libs << "lib"
   t.libs << "test"
   t.pattern = "test/**/*_test.rb"
 end
 
+desc "Run Rust tests"
+task :cargo_test do
+  sh "cargo test"
+end
+
+desc "Format Rust code"
+task :fmt do
+  sh "cargo fmt"
+end
+
+desc "Run Clippy linter"
+task :lint do
+  sh "cargo clippy -- -D warnings"
+end
+
+desc "Build native gem for platform (e.g., rake 'native[x86_64-linux]')"
+task :native, [:platform] do |_t, args|
+  abort "Usage: rake 'native[PLATFORM]' (e.g., x86_64-linux, aarch64-linux)" unless args[:platform]
+  sh "bundle", "exec", "rb-sys-dock", "--platform", args[:platform], "--build"
+end
+
 task purge: %i[clean clobber]
 
-desc "report gem version"
+desc "Print gem version"
 task :version do
   print GEMSPEC.version
 end
 
-Rake::Task["release"].clear # clear the existing release task to allow override
+task test: %i[compile ruby_test cargo_test]
+task default: %i[compile test]
+
+# Override bundler's release to push all platform gems
+Rake::Task["release"].clear
 Rake::Task["release:rubygem_push"].clear if Rake::Task.task_defined?("release:rubygem_push")
 
-# overrides bundler's default rake release task
-# we removed build and git tagging steps. Read more in ``./.github/workflows/release-ruby.yml`
-# read more https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/gem_helper.rb
-desc "Multi-arch release"
-task release: [
-  "release:guard_clean",
-  "release:rubygem_push"
-]
+desc "Release all platform gems to RubyGems"
+task release: ["release:guard_clean", "release:rubygem_push"]
 
 namespace :release do
-  desc "Push all gems to RubyGems"
   task :rubygem_push do
-    # Push all gem files (source + platform-specific) like Nokogiri does
-    # Bundler's built_gem_path only returns the last modified gem, so we glob all gems instead
-    gem_files = Gem::Util.glob_files_in_dir("#{GEMSPEC.name}-*.gem", "pkg").sort
+    gem_files = Dir.glob("pkg/#{GEMSPEC.name}-*.gem").sort
+    abort "No gems found in pkg/" if gem_files.empty?
 
-    if gem_files.empty?
-      abort "No gem files found in pkg/"
-    end
-
-    puts "Found #{gem_files.length} gem(s) to push:"
+    puts "Pushing #{gem_files.length} gem(s):"
     gem_files.each { |f| puts "  - #{File.basename(f)}" }
 
     gem_files.each do |gem_file|


### PR DESCRIPTION
## Changes

- Add `rake fmt` - runs `cargo fmt`
- Add `rake lint` - runs `cargo clippy`
- Add `rake cargo_test` - runs `cargo test`
- Add `rake native[platform]` - cross-compile via rb-sys-dock
- Add `rake default` - compile + test
- Rename test → ruby_test for clarity when combined with cargo_test
- Use `aarch64-linux` (standard naming) instead of `arm64-linux`
- Remove redundant `arm64-darwin23` (arm64-darwin covers all versions)
- Add error handling for gemspec loading
- Make standard/rake optional (fixes cross-compilation in Docker)

## References

- Platform naming: [oxi-test Rakefile](https://github.com/oxidize-rb/oxi-test/blob/main/Rakefile)
- Task patterns: [rb-sys examples](https://github.com/oxidize-rb/rb-sys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Rust dev/test rake tasks, updates cross-platform targets, and streamlines multi-arch release/publish flow.
> 
> - **Rake tasks**:
>   - Add `cargo_test`, `fmt`, `lint`, and `native[PLATFORM]` tasks.
>   - Rename `test` → `ruby_test`; new `test` aggregates `compile`, `ruby_test`, `cargo_test`; set `default` to `compile` + `test`.
> - **Cross-platform build**:
>   - Update `ext.cross_platform` to include `aarch64-linux` (replace `arm64-linux`) and remove `arm64-darwin23`.
>   - Keep Ruby version override for native gems in `cross_compiling`.
> - **Release/publish**:
>   - Override Bundler release; push all gems from `pkg/` via `release:rubygem_push` with improved globbing and output.
> - **Setup/robustness**:
>   - Make `standard/rake` optional; abort if `wreq.gemspec` cannot load.
>   - Add `version` description tweak; keep `purge` task.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46515427623db50b162ebd7bbb97e82b4cc3d27e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->