### PR TITLE
Fix release workflow permissions and Ruby 4.0 smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.3", "3.4"]
+        ruby: ["3.3", "3.4", "4.0"]
     steps:
       - uses: ruby/setup-ruby@v1
         with:
@@ -87,6 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add `contents: read` to the release job permissions — setting any `permissions` block zeros all unlisted ones, so `actions/checkout` was missing read access
- Add Ruby 4.0 to the smoke-test matrix to match the cross-compile step which already builds for `4.0,3.4,3.3`