### PR TITLE
feat(emulation): sync emulation targets with wreq-util 3.0.0-rc.10

### DIFF
--- a/lib/wreq_ruby/emulation.rb
+++ b/lib/wreq_ruby/emulation.rb
@@ -48,6 +48,8 @@ module Wreq
       Chrome141 = nil
       Chrome142 = nil
       Chrome143 = nil
+      Chrome144 = nil
+      Chrome145 = nil
       Edge101 = nil
       Edge122 = nil
       Edge127 = nil
@@ -61,6 +63,9 @@ module Wreq
       Edge140 = nil
       Edge141 = nil
       Edge142 = nil
+      Edge143 = nil
+      Edge144 = nil
+      Edge145 = nil
       Firefox109 = nil
       Firefox117 = nil
       Firefox128 = nil
@@ -76,6 +81,7 @@ module Wreq
       Firefox144 = nil
       Firefox145 = nil
       Firefox146 = nil
+      Firefox147 = nil
       SafariIos17_2 = nil
       SafariIos17_4_1 = nil
       SafariIos16_5 = nil
@@ -88,6 +94,7 @@ module Wreq
       Safari17_2_1 = nil
       Safari17_4_1 = nil
       Safari17_5 = nil
+      Safari17_6 = nil
       Safari18 = nil
       SafariIPad18 = nil
       Safari18_2 = nil
@@ -102,6 +109,8 @@ module Wreq
       SafariIos26_2 = nil
       SafariIPad26 = nil
       SafariIpad26_2 = nil
+      OkHttp3_9 = nil
+      OkHttp3_11 = nil
       OkHttp3_13 = nil
       OkHttp3_14 = nil
       OkHttp4_9 = nil

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -44,6 +44,8 @@ define_ruby_enum!(
     Chrome141,
     Chrome142,
     Chrome143,
+    Chrome144,
+    Chrome145,
     Edge101,
     Edge122,
     Edge127,
@@ -57,6 +59,9 @@ define_ruby_enum!(
     Edge140,
     Edge141,
     Edge142,
+    Edge143,
+    Edge144,
+    Edge145,
     Firefox109,
     Firefox117,
     Firefox128,
@@ -72,6 +77,7 @@ define_ruby_enum!(
     Firefox144,
     Firefox145,
     Firefox146,
+    Firefox147,
     SafariIos17_2,
     SafariIos17_4_1,
     SafariIos16_5,
@@ -84,6 +90,7 @@ define_ruby_enum!(
     Safari17_2_1,
     Safari17_4_1,
     Safari17_5,
+    Safari17_6,
     Safari18,
     SafariIPad18,
     Safari18_2,
@@ -98,6 +105,8 @@ define_ruby_enum!(
     SafariIos26_2,
     SafariIPad26,
     SafariIpad26_2,
+    OkHttp3_9,
+    OkHttp3_11,
     OkHttp3_13,
     OkHttp3_14,
     OkHttp4_9,
@@ -217,11 +226,25 @@ pub fn include(ruby: &Ruby, gem_module: &RModule) -> Result<(), Error> {
     emulation_class.const_set("Chrome140", EmulationDevice::Chrome140)?;
     emulation_class.const_set("Chrome141", EmulationDevice::Chrome141)?;
     emulation_class.const_set("Chrome142", EmulationDevice::Chrome142)?;
+    emulation_class.const_set("Chrome143", EmulationDevice::Chrome143)?;
+    emulation_class.const_set("Chrome144", EmulationDevice::Chrome144)?;
+    emulation_class.const_set("Chrome145", EmulationDevice::Chrome145)?;
     emulation_class.const_set("Edge101", EmulationDevice::Edge101)?;
     emulation_class.const_set("Edge122", EmulationDevice::Edge122)?;
     emulation_class.const_set("Edge127", EmulationDevice::Edge127)?;
     emulation_class.const_set("Edge131", EmulationDevice::Edge131)?;
     emulation_class.const_set("Edge134", EmulationDevice::Edge134)?;
+    emulation_class.const_set("Edge135", EmulationDevice::Edge135)?;
+    emulation_class.const_set("Edge136", EmulationDevice::Edge136)?;
+    emulation_class.const_set("Edge137", EmulationDevice::Edge137)?;
+    emulation_class.const_set("Edge138", EmulationDevice::Edge138)?;
+    emulation_class.const_set("Edge139", EmulationDevice::Edge139)?;
+    emulation_class.const_set("Edge140", EmulationDevice::Edge140)?;
+    emulation_class.const_set("Edge141", EmulationDevice::Edge141)?;
+    emulation_class.const_set("Edge142", EmulationDevice::Edge142)?;
+    emulation_class.const_set("Edge143", EmulationDevice::Edge143)?;
+    emulation_class.const_set("Edge144", EmulationDevice::Edge144)?;
+    emulation_class.const_set("Edge145", EmulationDevice::Edge145)?;
     emulation_class.const_set("Firefox109", EmulationDevice::Firefox109)?;
     emulation_class.const_set("Firefox117", EmulationDevice::Firefox117)?;
     emulation_class.const_set("Firefox128", EmulationDevice::Firefox128)?;
@@ -234,6 +257,10 @@ pub fn include(ruby: &Ruby, gem_module: &RModule) -> Result<(), Error> {
     emulation_class.const_set("Firefox139", EmulationDevice::Firefox139)?;
     emulation_class.const_set("Firefox142", EmulationDevice::Firefox142)?;
     emulation_class.const_set("Firefox143", EmulationDevice::Firefox143)?;
+    emulation_class.const_set("Firefox144", EmulationDevice::Firefox144)?;
+    emulation_class.const_set("Firefox145", EmulationDevice::Firefox145)?;
+    emulation_class.const_set("Firefox146", EmulationDevice::Firefox146)?;
+    emulation_class.const_set("Firefox147", EmulationDevice::Firefox147)?;
     emulation_class.const_set("SafariIos17_2", EmulationDevice::SafariIos17_2)?;
     emulation_class.const_set("SafariIos17_4_1", EmulationDevice::SafariIos17_4_1)?;
     emulation_class.const_set("SafariIos16_5", EmulationDevice::SafariIos16_5)?;
@@ -246,6 +273,7 @@ pub fn include(ruby: &Ruby, gem_module: &RModule) -> Result<(), Error> {
     emulation_class.const_set("Safari17_2_1", EmulationDevice::Safari17_2_1)?;
     emulation_class.const_set("Safari17_4_1", EmulationDevice::Safari17_4_1)?;
     emulation_class.const_set("Safari17_5", EmulationDevice::Safari17_5)?;
+    emulation_class.const_set("Safari17_6", EmulationDevice::Safari17_6)?;
     emulation_class.const_set("Safari18", EmulationDevice::Safari18)?;
     emulation_class.const_set("SafariIPad18", EmulationDevice::SafariIPad18)?;
     emulation_class.const_set("Safari18_2", EmulationDevice::Safari18_2)?;
@@ -254,8 +282,14 @@ pub fn include(ruby: &Ruby, gem_module: &RModule) -> Result<(), Error> {
     emulation_class.const_set("SafariIos18_1_1", EmulationDevice::SafariIos18_1_1)?;
     emulation_class.const_set("Safari18_5", EmulationDevice::Safari18_5)?;
     emulation_class.const_set("Safari26", EmulationDevice::Safari26)?;
+    emulation_class.const_set("Safari26_1", EmulationDevice::Safari26_1)?;
+    emulation_class.const_set("Safari26_2", EmulationDevice::Safari26_2)?;
     emulation_class.const_set("SafariIos26", EmulationDevice::SafariIos26)?;
+    emulation_class.const_set("SafariIos26_2", EmulationDevice::SafariIos26_2)?;
     emulation_class.const_set("SafariIPad26", EmulationDevice::SafariIPad26)?;
+    emulation_class.const_set("SafariIpad26_2", EmulationDevice::SafariIpad26_2)?;
+    emulation_class.const_set("OkHttp3_9", EmulationDevice::OkHttp3_9)?;
+    emulation_class.const_set("OkHttp3_11", EmulationDevice::OkHttp3_11)?;
     emulation_class.const_set("OkHttp3_13", EmulationDevice::OkHttp3_13)?;
     emulation_class.const_set("OkHttp3_14", EmulationDevice::OkHttp3_14)?;
     emulation_class.const_set("OkHttp4_9", EmulationDevice::OkHttp4_9)?;

--- a/test/emulation_test.rb
+++ b/test/emulation_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EmulationTest < Minitest::Test
+  def test_all_emulation_device_constants_are_non_nil
+    Wreq::EmulationDevice.constants.each do |name|
+      const = Wreq::EmulationDevice.const_get(name)
+      assert_instance_of Wreq::EmulationDevice, const,
+        "#{name} should be EmulationDevice, got #{const.inspect}"
+    end
+  end
+
+  def test_all_emulation_os_constants_are_non_nil
+    Wreq::EmulationOS.constants.each do |name|
+      const = Wreq::EmulationOS.const_get(name)
+      assert_instance_of Wreq::EmulationOS, const,
+        "#{name} should be EmulationOS, got #{const.inspect}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add 9 net-new emulation variants from `wreq-util 3.0.0-rc.10`: `Chrome144`, `Chrome145`, `Edge143`-`Edge145`, `Firefox147`, `Safari17_6`, `OkHttp3_9`, `OkHttp3_11`
- Fix 16 missing `const_set` registrations that were in the Rust macro but never exposed to Ruby, causing silent `nil` fallback: `Chrome143`, `Edge135`-`Edge142`, `Firefox144`-`Firefox146`, `Safari26_1`, `Safari26_2`, `SafariIos26_2`, `SafariIpad26_2`
- Add smoke test that verifies every `EmulationDevice` and `EmulationOS` constant is a non-nil instance of the correct type (108 device + 5 OS assertions)

## Three Locations Synced

| Location | File | Purpose |
|---|---|---|
| `define_ruby_enum!` macro | `src/emulation.rs:6-120` | Rust enum + FFI conversion |
| `const_set` calls | `src/emulation.rs:195-302` | Ruby VM constant registration |
| Ruby doc stubs | `lib/wreq_ruby/emulation.rb` | YARD documentation fallback |