### PR TITLE
Update README with SearchApi branding, fix references, and sync emulations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wreq-ruby"
 description = "Ruby bindings for Wreq, HTTP client library in Rust."
 authors = ["SearchApi <support@searchapi.io>"]
-homepage = "https://github.com/SearchApi"
+homepage = "https://github.com/SearchApi/wreq-ruby"
 repository = "https://github.com/SearchApi/wreq-ruby"
 edition = "2024"
 rust-version = "1.85"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # wreq-ruby
 
+[![Gem Version](https://badge.fury.io/rb/wreq.svg)](https://rubygems.org/gems/wreq)
 [![CI](https://github.com/SearchApi/wreq-ruby/actions/workflows/ci.yml/badge.svg)](https://github.com/SearchApi/wreq-ruby/actions/workflows/ci.yml)
 
- An easy and powerful Ruby HTTP client with advanced browser fingerprinting that accurately emulates **Chrome**, **Firefox**, **Safari**, **Opera**, and **OkHttp**, with precise **TLS/HTTP2** signatures, and powered by [wreq](https://github.com/0x676e67/wreq).
-
+An easy and powerful Ruby HTTP client with advanced browser fingerprinting that accurately emulates **Chrome**, **Edge**, **Firefox**, **Safari**, **Opera**, and **OkHttp**, with precise **TLS/HTTP2** signatures, and powered by [wreq](https://github.com/0x676e67/wreq).
 
 ## Features
 
-- Plain bodies, JSON, urlencoded,
+- Plain bodies, JSON, urlencoded
 - Cookie Store
 - Redirect Policy
 - Original Headers
@@ -18,22 +18,30 @@
 - Free-Threaded Safety
 - Automatic Decompression
 
-## Example
-
-This example demonstrates how to make a simple GET request using the `wreq` library. So you need install `wreq` and run the following code:
+## Installation
 
 ```bash
 gem install wreq
 ```
 
-And then the code:
+Or add to your Gemfile:
+
+```ruby
+gem "wreq"
+```
+
+Pre-compiled native gems are available for:
+- Linux (x86_64, aarch64)
+- macOS (arm64)
+
+## Example
 
 ```ruby
 require "wreq"
 
- # Build a client
+# Build a client
 client = Wreq::Client.new(emulation: Wreq::Emulation.new(
-  device: Wreq::EmulationDevice::Chrome142,
+  device: Wreq::EmulationDevice::Chrome145,
   os: Wreq::EmulationOS::MacOS,
   skip_http2: false,
   skip_headers: false
@@ -50,11 +58,11 @@ Additional learning resources include:
 - [Repository Tests](https://github.com/SearchApi/wreq-ruby/tree/main/test)
 - [Repository Examples](https://github.com/SearchApi/wreq-ruby/tree/main/examples)
 
-## Behavior
+## Browser Emulation
 
 1. **HTTP/2 over TLS**
 
-Due to the complexity of TLS encryption and the widespread adoption of HTTP/2, browser fingerprints such as **JA3**, **JA4**, and **Akamai** cannot be reliably emulated using simple fingerprint strings. Instead of parsing and emulating these string-based fingerprints, `rnet` provides fine-grained control over TLS and HTTP/2 extensions and settings for precise browser behavior emulation.
+Due to the complexity of TLS encryption and the widespread adoption of HTTP/2, browser fingerprints such as **JA3**, **JA4**, and **Akamai** cannot be reliably emulated using simple fingerprint strings. Instead of parsing and emulating these string-based fingerprints, `wreq` provides fine-grained control over TLS and HTTP/2 extensions and settings for precise browser behavior emulation.
 
 2. **Device Emulation**
 
@@ -72,17 +80,20 @@ Most browser device models share identical TLS and HTTP/2 configurations, differ
   | **iOS**     | iOS (iPhone/iPad)              |
 
   </details>
+
+<!-- Emulation profiles sourced from src/emulation.rs - keep in sync -->
+
 - <details>
   <summary>Available browser emulations</summary>
 
-  | **Browser** | **Versions**                                                                                                                                                                                                                                                                                                                                                                            |
-  | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | **Chrome**  | `Chrome100`, `Chrome101`, `Chrome104`, `Chrome105`, `Chrome106`, `Chrome107`, `Chrome108`, `Chrome109`, `Chrome110`, `Chrome114`, `Chrome116`, `Chrome117`, `Chrome118`, `Chrome119`, `Chrome120`, `Chrome123`, `Chrome124`, `Chrome126`, `Chrome127`, `Chrome128`, `Chrome129`, `Chrome130`, `Chrome131`, `Chrome132`, `Chrome133`, `Chrome134`, `Chrome135`, `Chrome136`, `Chrome137`, `Chrome138`, `Chrome139`, `Chrome140`, `Chrome141`, `Chrome142`, `Chrome143` |
-  | **Safari**  | `SafariIos17_2`, `SafariIos17_4_1`, `SafariIos16_5`, `Safari15_3`, `Safari15_5`, `Safari15_6_1`, `Safari16`, `Safari16_5`, `Safari17_0`, `Safari17_2_1`, `Safari17_4_1`, `Safari17_5`, `Safari18`, `SafariIPad18`, `Safari18_2`, `SafariIos18_1_1`, `Safari18_3`, `Safari18_3_1`, `Safari18_5`,  `Safari26`, `Safari26_1`, `Safari26_2`, `SafariIos26`, `SafariIos26_2`, `SafariIPad26`, `SafariIpad26_2`  |
-  | **Firefox** | `Firefox109`, `Firefox117`, `Firefox128`, `Firefox133`, `Firefox135`, `FirefoxPrivate135`, `FirefoxAndroid135`, `Firefox136`, `FirefoxPrivate136`, `Firefox139`, `Firefox142`, `Firefox143`, `Firefox144`, `Firefox145`, `Firefox146` |
-  | **OkHttp**  | `OkHttp3_9`, `OkHttp3_11`, `OkHttp3_13`, `OkHttp3_14`, `OkHttp4_9`, `OkHttp4_10`, `OkHttp4_12`, `OkHttp5`                                                                                                                                                                                                                                                                               |
-  | **Edge**    | `Edge101`, `Edge122`, `Edge127`, `Edge131`, `Edge134`, `Edge135`, `Edge136`, `Edge137`, `Edge138`, `Edge139`, `Edge140`, `Edge141`, `Edge142`|
-  | **Opera**   | `Opera116`, `Opera117`, `Opera118`, `Opera119`                                                                                                                                                                 |
+  | **Browser** | **Versions** |
+  | ----------- | ------------ |
+  | **Chrome**  | `Chrome100`, `Chrome101`, `Chrome104`, `Chrome105`, `Chrome106`, `Chrome107`, `Chrome108`, `Chrome109`, `Chrome110`, `Chrome114`, `Chrome116`, `Chrome117`, `Chrome118`, `Chrome119`, `Chrome120`, `Chrome123`, `Chrome124`, `Chrome126`, `Chrome127`, `Chrome128`, `Chrome129`, `Chrome130`, `Chrome131`, `Chrome132`, `Chrome133`, `Chrome134`, `Chrome135`, `Chrome136`, `Chrome137`, `Chrome138`, `Chrome139`, `Chrome140`, `Chrome141`, `Chrome142`, `Chrome143`, `Chrome144`, `Chrome145` |
+  | **Edge**    | `Edge101`, `Edge122`, `Edge127`, `Edge131`, `Edge134`, `Edge135`, `Edge136`, `Edge137`, `Edge138`, `Edge139`, `Edge140`, `Edge141`, `Edge142`, `Edge143`, `Edge144`, `Edge145` |
+  | **Firefox** | `Firefox109`, `Firefox117`, `Firefox128`, `Firefox133`, `Firefox135`, `FirefoxPrivate135`, `FirefoxAndroid135`, `Firefox136`, `FirefoxPrivate136`, `Firefox139`, `Firefox142`, `Firefox143`, `Firefox144`, `Firefox145`, `Firefox146`, `Firefox147` |
+  | **Safari**  | `Safari15_3`, `Safari15_5`, `Safari15_6_1`, `Safari16`, `Safari16_5`, `Safari17_0`, `Safari17_2_1`, `Safari17_4_1`, `Safari17_5`, `Safari17_6`, `Safari18`, `Safari18_2`, `Safari18_3`, `Safari18_3_1`, `Safari18_5`, `Safari26`, `Safari26_1`, `Safari26_2`, `SafariIos16_5`, `SafariIos17_2`, `SafariIos17_4_1`, `SafariIos18_1_1`, `SafariIos26`, `SafariIos26_2`, `SafariIPad18`, `SafariIPad26`, `SafariIpad26_2` |
+  | **OkHttp**  | `OkHttp3_9`, `OkHttp3_11`, `OkHttp3_13`, `OkHttp3_14`, `OkHttp4_9`, `OkHttp4_10`, `OkHttp4_12`, `OkHttp5` |
+  | **Opera**   | `Opera116`, `Opera117`, `Opera118`, `Opera119` |
 
   </details>
 
@@ -106,7 +117,7 @@ gem build wreq.gemspec
 gem install wreq-*.gem
 
 # Option 2: Build pre-compiled platform gem (recommended for distribution)
-# This creates a platform-specific gem (e.g., wreq-0.1.0-arm64-darwin.gem) 
+# This creates a platform-specific gem (e.g., wreq-0.1.0-arm64-darwin.gem)
 # with pre-compiled binaries. Users can install quickly without build environment.
 bundle exec rake compile
 bundle exec rake native gem
@@ -114,7 +125,7 @@ gem install pkg/wreq-*.gem
 
 # Development workflow
 bundle exec rake compile    # Compile for development/testing
-bundle exec rake test       # Run tests  
+bundle exec rake test       # Run tests
 bundle exec ruby examples/body.rb  # Run examples without installing
 ```
 
@@ -122,6 +133,18 @@ bundle exec ruby examples/body.rb  # Run examples without installing
 
 Licensed under either of Apache License, Version 2.0 ([LICENSE](./LICENSE) or http://www.apache.org/licenses/LICENSE-2.0).
 
-## Contribution
+## Contributing
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the [Apache-2.0](./LICENSE) license, shall be licensed as above, without any additional terms or conditions.
+
+## Maintained by
+
+<a href="https://www.searchapi.io">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://www.searchapi.io/press/v2/svg/searchapi_logo_white_h.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://www.searchapi.io/press/v2/svg/searchapi_logo_black_h.svg">
+    <img alt="SearchAPI" src="https://www.searchapi.io/press/v2/svg/searchapi_logo_black_h.svg" height="40px" style="vertical-align: middle;">
+  </picture>
+</a>
+
+[SearchApi](https://www.searchapi.io) - real-time low-latency SERP API with 100+ scrapers. Trusted by Fortune 500 and leading AI companies.

--- a/wreq.gemspec
+++ b/wreq.gemspec
@@ -22,13 +22,16 @@ Gem::Specification.new do |spec|
     .fetch("version")
   spec.authors = ["SearchApi"]
   spec.email = ["support@searchapi.io"]
-  spec.summary = "Ruby bindings for Wreq, HTTP client library in Rust."
-  spec.homepage = "https://github.com/SearchApi"
+  spec.summary = "Ruby bindings for wreq, an HTTP client with TLS/HTTP2 browser fingerprinting"
+  spec.description = "An easy and powerful Ruby HTTP client with advanced browser fingerprinting " \
+                     "that accurately emulates Chrome, Edge, Firefox, Safari, Opera, and OkHttp " \
+                     "with precise TLS/HTTP2 signatures. Powered by wreq (Rust) and BoringSSL."
+  spec.homepage = "https://github.com/SearchApi/wreq-ruby"
   spec.license = "Apache-2.0"
   spec.metadata = {
     "bug_tracker_uri" => "https://github.com/SearchApi/wreq-ruby/issues",
     "changelog_uri" => "https://github.com/SearchApi/wreq-ruby/releases",
-    "documentation_uri" => "https://github.com/SearchApi/wreq-ruby/README.md",
+    "documentation_uri" => "https://github.com/SearchApi/wreq-ruby#readme",
     "homepage_uri" => spec.homepage,
     "source_code_uri" => "https://github.com/SearchApi/wreq-ruby",
     "rubygems_mfa_required" => "true"
@@ -51,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.extensions = ["./extconf.rb"]
 
   # Exclude non-Ruby files from RDoc to prevent parsing errors
-  spec.rdoc_options = ["--exclude", "Cargo\\..*", "--exclude", "--exclude", "\\.rs$"]
+  spec.rdoc_options = ["--exclude", "Cargo\\..*", "--exclude", "\\.rs$"]
 
   spec.requirements = ["Rust >= 1.85"]
   # use a Ruby version which:


### PR DESCRIPTION
## Summary

Improve README and gemspec for the wreq-ruby gem:

- Add SearchApi branding with dark/light theme logo
- Fix `rnet` → `wreq` typo in Browser Emulation section
- Add missing emulation profiles (Chrome144/145, Edge143-145, Firefox147, Safari17_6)
- Add Edge to the tagline
- Add Installation section and Gem Version badge
- Clean up filler prose, rename sections for clarity
- Update example to Chrome145
- Fix gemspec homepage, summary, description, documentation link, and duplicate rdoc option
- Fix Cargo.toml homepage