### PR TITLE
test(proxy): fix proxy tests under Tunnel network mode

### DIFF
--- a/test/error_handling_test.rb
+++ b/test/error_handling_test.rb
@@ -82,7 +82,10 @@ class ErrorHandlingTest < Minitest::Test
         Wreq.get(url, proxy: proxy, timeout: 5)
         flunk "Expected proxy connection error but got response"
       rescue => e
-        assert_instance_of Wreq::ProxyConnectionError, e
+        assert(
+          e.is_a?(Wreq::ProxyConnectionError) || e.is_a?(Wreq::RequestError),
+          "Expected ProxyConnectionError or RequestError, got #{e.class}: #{e.message}"
+        )
       end
     end
   end


### PR DESCRIPTION
When you enable Tunnel mode with local proxy tools, proxy requests will always succeed and the network connection stays stable all the time, simply because this is the local Tunnel mode.