### PR TITLE
Add custom #inspect to core classes for console readability

### DIFF
--- a/lib/wreq_ruby/client.rb
+++ b/lib/wreq_ruby/client.rb
@@ -514,3 +514,11 @@ unless defined?(Wreq)
     end
   end
 end
+
+module Wreq
+  class Client
+    def inspect
+      "#<Wreq::Client>"
+    end
+  end
+end

--- a/lib/wreq_ruby/cookie.rb
+++ b/lib/wreq_ruby/cookie.rb
@@ -142,3 +142,22 @@ unless defined?(Wreq)
     end
   end
 end
+
+module Wreq
+  class Cookie
+    def inspect
+      parts = ["#<Wreq::Cookie", name]
+      parts << "domain=#{domain}" if domain
+      parts << "path=#{path}" if path
+      parts << "secure" if secure?
+      parts << "http_only" if http_only?
+      parts.join(" ") + ">"
+    end
+  end
+
+  class Jar
+    def inspect
+      "#<Wreq::Jar [#{get_all.length} cookies]>"
+    end
+  end
+end

--- a/lib/wreq_ruby/header.rb
+++ b/lib/wreq_ruby/header.rb
@@ -195,3 +195,11 @@ unless defined?(Wreq)
     end
   end
 end
+
+module Wreq
+  class Headers
+    def inspect
+      "#<Wreq::Headers [#{length} headers]>"
+    end
+  end
+end

--- a/lib/wreq_ruby/http.rb
+++ b/lib/wreq_ruby/http.rb
@@ -130,3 +130,17 @@ module Wreq
     end
   end
 end
+
+module Wreq
+  class StatusCode
+    def inspect
+      "#<Wreq::StatusCode #{to_s}>"
+    end
+  end
+
+  class Version
+    def inspect
+      "#<Wreq::Version #{to_s}>"
+    end
+  end
+end

--- a/lib/wreq_ruby/response.rb
+++ b/lib/wreq_ruby/response.rb
@@ -156,27 +156,35 @@ end
 
 module Wreq
   class Response
-    # Returns a compact string representation of the response.
+    # Returns the response body as a string.
+    #
+    # @return [String] Response body text
+    # @example
+    #   puts response.to_s
+    #   puts response
+    #   File.write("page.html", response)
+    def to_s
+      text
+    end
+
+    # Returns a compact string representation for debugging.
     #
     # Format: #<Wreq::Response STATUS content-type="..." body=SIZE>
     #
     # @return [String] Compact formatted response information
     # @example
-    #   puts response.to_s
+    #   p response
     #   # => #<Wreq::Response 200 content-type="application/json" body=456B>
-    def to_s
+    def inspect
       parts = ["#<Wreq::Response"]
 
-      # Status code
       parts << code.to_s
 
-      # Content-Type header if present
       if headers.respond_to?(:get)
         content_type = headers.get("content-type")
         parts << "content-type=#{content_type.inspect}" if content_type
       end
 
-      # Body size
       if content_length
         parts << "body=#{format_bytes(content_length)}"
       end

--- a/test/inspect_test.rb
+++ b/test/inspect_test.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InspectTest < Minitest::Test
+  # ---- Headers ----
+
+  def test_headers_inspect_empty
+    headers = Wreq::Headers.new
+    assert_equal "#<Wreq::Headers [0 headers]>", headers.inspect
+  end
+
+  def test_headers_inspect_with_entries
+    headers = Wreq::Headers.new
+    headers.set("Content-Type", "text/html")
+    headers.set("Accept", "application/json")
+    assert_equal "#<Wreq::Headers [2 headers]>", headers.inspect
+  end
+
+  # ---- Cookie ----
+
+  def test_cookie_inspect_minimal
+    c = Wreq::Cookie.new("sid", "secret123")
+    result = c.inspect
+    assert_includes result, "#<Wreq::Cookie"
+    assert_includes result, "sid"
+    refute_includes result, "secret123"
+    assert result.end_with?(">")
+  end
+
+  def test_cookie_inspect_with_domain_and_path
+    c = Wreq::Cookie.new("sid", "val",
+      domain: "example.com",
+      path: "/app")
+    result = c.inspect
+    assert_includes result, "domain=example.com"
+    assert_includes result, "path=/app"
+  end
+
+  def test_cookie_inspect_with_flags
+    c = Wreq::Cookie.new("sid", "val",
+      secure: true,
+      http_only: true)
+    result = c.inspect
+    assert_includes result, "secure"
+    assert_includes result, "http_only"
+  end
+
+  def test_cookie_inspect_omits_nil_attributes
+    c = Wreq::Cookie.new("sid", "val")
+    result = c.inspect
+    refute_includes result, "domain="
+    refute_includes result, "path="
+    refute_includes result, "secure"
+    refute_includes result, "http_only"
+  end
+
+  # ---- Jar ----
+
+  def test_jar_inspect_empty
+    jar = Wreq::Jar.new
+    assert_equal "#<Wreq::Jar [0 cookies]>", jar.inspect
+  end
+
+  def test_jar_inspect_with_cookies
+    jar = Wreq::Jar.new
+    jar.add_cookie_str("a=1; Path=/", "https://example.com")
+    jar.add_cookie_str("b=2; Path=/", "https://example.com")
+    assert_equal "#<Wreq::Jar [2 cookies]>", jar.inspect
+  end
+
+  # ---- Client ----
+
+  def test_client_inspect
+    client = Wreq::Client.new
+    assert_equal "#<Wreq::Client>", client.inspect
+  end
+
+  def test_client_inspect_with_options
+    client = Wreq::Client.new(timeout: 30, gzip: true)
+    assert_equal "#<Wreq::Client>", client.inspect
+  end
+
+  # ---- Response ----
+
+  def test_response_to_s_returns_body
+    response = Wreq.get("http://localhost:8080/json")
+    assert_equal response.text, response.to_s
+  end
+
+  def test_response_inspect_format
+    response = Wreq.get("http://localhost:8080/json")
+    result = response.inspect
+    assert result.start_with?("#<Wreq::Response")
+    assert_includes result, "200"
+    assert result.end_with?(">")
+  end
+
+  # ---- StatusCode ----
+
+  def test_status_code_inspect
+    response = Wreq.get("http://localhost:8080/status/200")
+    result = response.status.inspect
+    assert result.start_with?("#<Wreq::StatusCode")
+    assert_includes result, response.status.to_s
+    assert result.end_with?(">")
+  end
+
+  # ---- Version ----
+
+  def test_version_inspect_from_constant
+    v = Wreq::Version::HTTP_11
+    result = v.inspect
+    assert result.start_with?("#<Wreq::Version")
+    assert_includes result, v.to_s
+    assert result.end_with?(">")
+  end
+
+  def test_version_inspect_from_response
+    response = Wreq.get("http://localhost:8080/get")
+    result = response.version.inspect
+    assert result.start_with?("#<Wreq::Version")
+    assert result.end_with?(">")
+  end
+end


### PR DESCRIPTION
## Why

All Wreq classes currently use Ruby's default `#inspect`, which dumps unhelpful output like `#<Wreq::Response:0x0000000120b11798>` in IRB/Pry. This makes debugging tedious because you can't see status codes, headers, or cookie details at a glance.

## What changed

Added `#inspect` to 7 core classes with compact, informative output:

```ruby
response.inspect  #=> #<Wreq::Response 200 content-type="application/json" body=1.2KB>
headers.inspect   #=> #<Wreq::Headers [5 headers]>
cookie.inspect    #=> #<Wreq::Cookie sid domain=example.com path=/ secure http_only>
jar.inspect       #=> #<Wreq::Jar [3 cookies]>
client.inspect    #=> #<Wreq::Client>
status.inspect    #=> #<Wreq::StatusCode 200 OK>
version.inspect   #=> #<Wreq::Version HTTP/1.1>
```

`Response#to_s` now returns body text (matching HTTP.rb, HTTParty, RestClient conventions), so `puts response` prints the body rather than the debug summary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly debug/console-output changes, but `Response#to_s` behavior changes and could affect callers relying on the previous string representation.
> 
> **Overview**
> Adds custom `#inspect` implementations for `Wreq::Client`, `Wreq::Headers`, `Wreq::Cookie`, `Wreq::Jar`, `Wreq::StatusCode`, and `Wreq::Version` to provide compact, non-sensitive console output (e.g., counts/flags vs. dumping object ids or cookie values).
> 
> Changes `Wreq::Response` so `to_s` now returns the response body (`text`) and moves the prior compact debug formatting to `inspect` (including status, optional `content-type`, and formatted body size). Adds `test/inspect_test.rb` to cover the new `inspect`/`to_s` expectations across these types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c33869463abb8101bcf2b377ecaeb230d377d657. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->