### PR TITLE
refactor(cookie): merge `add` and `add_cookie_str` methods

### DIFF
--- a/lib/wreq_ruby/cookie.rb
+++ b/lib/wreq_ruby/cookie.rb
@@ -114,18 +114,11 @@ unless defined?(Wreq)
       def get_all
       end
 
-      # Add a cookie object for the given URL.
-      # @param cookie [Wreq::Cookie]
-      # @param url [String]
-      # @return [void]
-      def add_cookie(cookie, url)
-      end
-
       # Add a cookie from a Set-Cookie string for the given URL.
-      # @param cookie [String] A Set-Cookie string
+      # @param cookie [String, Wreq::Cookie] A Set-Cookie string
       # @param url [String]
       # @return [void]
-      def add_cookie_str(cookie, url)
+      def add(cookie, url)
       end
 
       # Remove a cookie by name for the given URL.

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -265,13 +265,14 @@ impl Jar {
     }
 
     /// Add a cookie to this jar.
-    pub fn add_cookie(&self, cookie: &Cookie, url: String) {
-        gvl::nogvl(|| self.0.add(cookie.0.clone(), &url))
-    }
+    pub fn add(&self, cookie: Value, url: String) {
+        if let Ok(cookie) = Obj::<Cookie>::try_convert(cookie) {
+            gvl::nogvl(|| self.0.add(cookie.0.clone(), &url))
+        }
 
-    /// Add a cookie str to this jar.
-    pub fn add_cookie_str(&self, cookie: String, url: String) {
-        gvl::nogvl(|| self.0.add(cookie.as_ref(), &url))
+        if let Ok(cookie_str) = String::try_convert(cookie) {
+            gvl::nogvl(|| self.0.add(cookie_str.as_ref(), &url))
+        }
     }
 
     /// Remove a cookie from this jar by name and URL.
@@ -312,8 +313,7 @@ pub fn include(ruby: &Ruby, gem_module: &RModule) -> Result<(), Error> {
     let jar_class = gem_module.define_class("Jar", ruby.class_object())?;
     jar_class.define_singleton_method("new", function!(Jar::new, 0))?;
     jar_class.define_method("get_all", method!(Jar::get_all, 0))?;
-    jar_class.define_method("add_cookie", method!(Jar::add_cookie, 2))?;
-    jar_class.define_method("add_cookie_str", method!(Jar::add_cookie_str, 2))?;
+    jar_class.define_method("add", method!(Jar::add, 2))?;
     jar_class.define_method("remove", method!(Jar::remove, 2))?;
     jar_class.define_method("clear", method!(Jar::clear, 0))?;
 

--- a/test/client_cookie_test.rb
+++ b/test/client_cookie_test.rb
@@ -36,7 +36,7 @@ class ClientCookieProviderTest < Minitest::Test
 
   def test_prepopulated_jar_is_used_by_client
     # pre-populate jar
-    @jar.add_cookie_str("pref=1; Path=/", "#{HOST}/")
+    @jar.add("pref=1; Path=/", "#{HOST}/")
 
     res = @client.get("#{HOST}/cookies")
     assert_equal 200, res.code

--- a/test/cookie_test.rb
+++ b/test/cookie_test.rb
@@ -19,9 +19,9 @@ class CookieTest < Minitest::Test
     assert_equal 0, cookies.length
   end
 
-  def test_add_cookie_str_and_get_all
+  def test_add_and_get_all
     set_cookie = "sid=abc123; Path=/; Domain=example.com; HttpOnly; Secure"
-    @jar.add_cookie_str(set_cookie, @base_url)
+    @jar.add(set_cookie, @base_url)
 
     cookies = @jar.get_all
     assert_kind_of Array, cookies
@@ -42,9 +42,9 @@ class CookieTest < Minitest::Test
   end
 
   def test_add_multiple_and_remove
-    @jar.add_cookie_str("a=1; Path=/", @base_url)
-    @jar.add_cookie_str("b=2; Path=/", @base_url)
-    @jar.add_cookie_str("c=3; Path=/", @base_url)
+    @jar.add("a=1; Path=/", @base_url)
+    @jar.add("b=2; Path=/", @base_url)
+    @jar.add("c=3; Path=/", @base_url)
 
     cookies = @jar.get_all
     assert_equal 3, cookies.length
@@ -58,8 +58,8 @@ class CookieTest < Minitest::Test
   end
 
   def test_clear
-    @jar.add_cookie_str("x=1; Path=/", @base_url)
-    @jar.add_cookie_str("y=2; Path=/", @base_url)
+    @jar.add("x=1; Path=/", @base_url)
+    @jar.add("y=2; Path=/", @base_url)
     refute_empty @jar.get_all
 
     @jar.clear
@@ -69,7 +69,7 @@ class CookieTest < Minitest::Test
   def test_max_age_and_expires_optional
     # Max-Age only
     @jar.clear
-    @jar.add_cookie_str("ma=1; Max-Age=3600; Path=/", @base_url)
+    @jar.add("ma=1; Max-Age=3600; Path=/", @base_url)
     c1 = @jar.get_all.find { |c| c.name == "ma" }
     assert c1
     # can be nil or Integer; just ensure responds and is truthy integer
@@ -81,7 +81,7 @@ class CookieTest < Minitest::Test
     # Expires only
     @jar.clear
     t = Time.now + 3600
-    @jar.add_cookie_str("exp=1; Expires=#{t.gmtime.strftime("%a, %d %b %Y %H:%M:%S GMT")}; Path=/", @base_url)
+    @jar.add("exp=1; Expires=#{t.gmtime.strftime("%a, %d %b %Y %H:%M:%S GMT")}; Path=/", @base_url)
     c2 = @jar.get_all.find { |c| c.name == "exp" }
     assert c2
     # expires returns Float (unix seconds) or nil
@@ -144,8 +144,8 @@ class CookieTest < Minitest::Test
 
   def test_same_site_flags_from_parsed_header
     @jar.clear
-    @jar.add_cookie_str("s1=1; Path=/; SameSite=Strict", @base_url)
-    @jar.add_cookie_str("s2=1; Path=/; SameSite=Lax", @base_url)
+    @jar.add("s1=1; Path=/; SameSite=Strict", @base_url)
+    @jar.add("s2=1; Path=/; SameSite=Lax", @base_url)
 
     cookies = @jar.get_all
     h = cookies.to_h { |ck| [ck.name, [ck.same_site_strict?, ck.same_site_lax?]] }

--- a/test/inspect_test.rb
+++ b/test/inspect_test.rb
@@ -64,8 +64,8 @@ class InspectTest < Minitest::Test
 
   def test_jar_inspect_with_cookies
     jar = Wreq::Jar.new
-    jar.add_cookie_str("a=1; Path=/", "https://example.com")
-    jar.add_cookie_str("b=2; Path=/", "https://example.com")
+    jar.add("a=1; Path=/", "https://example.com")
+    jar.add("b=2; Path=/", "https://example.com")
     assert_equal "#<Wreq::Jar [2 cookies]>", jar.inspect
   end
 


### PR DESCRIPTION
This is a breaking update. It uses Ruby's dynamic parameter merging mechanism to reduce redundancy.
