### PR TITLE
build(deps): update wreq dependency version to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,18 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,6 +31,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "arc-swap"
@@ -96,31 +90,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
-name = "boring-sys2"
-version = "5.0.0-alpha.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455d79965f5155dcc88a7abce112c3590883889131b799beda10bf9a813ed669"
-dependencies = [
- "bindgen",
- "cmake",
- "fs_extra",
- "fslock",
-]
-
-[[package]]
-name = "boring2"
-version = "5.0.0-alpha.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183ccc3854411c035410dcdbffafca62084f3a6c33f013c77e83c025d2a08a28"
-dependencies = [
- "bitflags",
- "boring-sys2",
- "foreign-types",
- "libc",
- "openssl-macros",
-]
-
-[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +108,31 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "btls"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c5e60b8c8d282c86360cab651ded04ab0335a7b5390c8d34145cbeab8cacf5f"
+dependencies = [
+ "bitflags",
+ "btls-sys",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+]
+
+[[package]]
+name = "btls-sys"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1b8638a2e1c38a5ae4efa90ae57e643baec35a30d03fc5b399b893adc4954b"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "fs_extra",
+ "fslock",
 ]
 
 [[package]]
@@ -323,6 +317,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,15 +433,14 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "http"
@@ -489,7 +488,6 @@ dependencies = [
  "futures-sink",
  "http",
  "indexmap",
- "parking_lot",
  "slab",
  "smallvec",
  "tokio",
@@ -611,7 +609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown",
  "serde",
  "serde_core",
 ]
@@ -682,6 +680,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -762,12 +769,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "once_cell"
-version = "1.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl-macros"
@@ -953,17 +954,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "schnellru"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356285bbf17bea63d9e52e96bd18f039672ac92b55b8cb997d6162a2a37d1649"
-dependencies = [
- "ahash",
- "cfg-if",
- "hashbrown 0.13.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +996,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_html_form"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0946d52b4b7e28823148aebbeceb901012c595ad737920d504fa8634bb099e6f"
+dependencies = [
+ "form_urlencoded",
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,18 +1030,6 @@ dependencies = [
  "magnus",
  "serde",
  "tap",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -1234,12 +1225,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-boring2"
-version = "5.0.0-alpha.13"
+name = "tokio-btls"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f81df1210d791f31d72d840de8fbd80b9c3cb324956523048b1413e2bd55756"
+checksum = "2e1fd638ec35427faf3b8f412e0fdd6fae76591d79dba40f38fa667d22bc44dd"
 dependencies = [
- "boring2",
+ "btls",
  "tokio",
 ]
 
@@ -1490,17 +1481,13 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 [[package]]
 name = "wreq"
 version = "6.0.0-rc.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79937f6c4df65b3f6f78715b9de2977afe9ee3b3436483c7949a24511e25935"
+source = "git+https://github.com/0x676e67/wreq#e8781fba28269e91ed4480189c56fbeb6743aeb3"
 dependencies = [
- "ahash",
- "boring2",
- "brotli",
+ "btls",
+ "btls-sys",
  "bytes",
  "cookie",
  "encoding_rs",
- "flate2",
- "futures-channel",
  "futures-util",
  "http",
  "http-body",
@@ -1509,28 +1496,58 @@ dependencies = [
  "httparse",
  "ipnet",
  "libc",
+ "lru",
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "schnellru",
  "serde",
+ "serde_html_form",
  "serde_json",
- "serde_urlencoded",
- "smallvec",
  "socket2",
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-boring2",
+ "tokio-btls",
  "tokio-socks",
  "tokio-util",
  "tower",
  "tower-http",
  "url",
- "want",
  "webpki-root-certs",
  "windows-registry",
- "zstd",
+ "wreq-proto",
+ "wreq-rt",
+]
+
+[[package]]
+name = "wreq-proto"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e00cad3a0dfbb04dd4bb18788fb1b5d24be15356e7f85684760f5e0fca698fd5"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "http2",
+ "httparse",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "want",
+]
+
+[[package]]
+name = "wreq-rt"
+version = "0.2.2-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2351898706a6040f2c789e2924e8b248daa157bc577cc629534fad76498d8c5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+ "wreq-proto",
 ]
 
 [[package]]
@@ -1556,12 +1573,14 @@ dependencies = [
 
 [[package]]
 name = "wreq-util"
-version = "3.0.0-rc.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51558351cf26c9a5daeabf5df5bfab13f1666fa783ad7ddb9a573e04d7fae0a"
+version = "3.0.0-rc.10"
+source = "git+https://github.com/0x676e67/wreq-util#a568b26f3d3a44380ef59c07308ae7a4ad965fc9"
 dependencies = [
+ "brotli",
+ "flate2",
  "typed-builder",
  "wreq",
+ "zstd",
 ]
 
 [[package]]
@@ -1591,26 +1610,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "wreq_ruby"
 magnus = { version = "0.8.2", features = ["bytes"] }
 rb-sys = { version = "0.9.128", default-features = false }
 tokio = { version = "1.52.3", features = ["full"] }
-wreq = { version = "6.0.0-rc.28", features = [
+wreq = { git = "https://github.com/0x676e67/wreq", features = [
     "query",
     "form",
     "json",
@@ -31,7 +31,7 @@ wreq = { version = "6.0.0-rc.28", features = [
     "zstd",
     "system-proxy",
 ] }
-wreq-util = { version = "3.0.0-rc.11", features = ["emulation-compression"] }
+wreq-util = { git = "https://github.com/0x676e67/wreq-util", features = ["emulation-compression"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_magnus = "0.11.0"
 indexmap = { version = "2.14.0", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ require "wreq"
 
 # Build a client
 client = Wreq::Client.new(emulation: Wreq::Emulation.new(
-  device: Wreq::EmulationDevice::Chrome147,
-  os: Wreq::EmulationOS::MacOS,
-  skip_http2: false,
-  skip_headers: false
+  profile: Wreq::Profile::Chrome147,
+  platform: Wreq::Platform::MacOS,
+  http2: true,
+  headers: true
 ))
 
 # Use the API you're already familiar with

--- a/examples/emulate_request.rb
+++ b/examples/emulate_request.rb
@@ -11,10 +11,10 @@ require_relative "../lib/wreq"
 #   Set when creating the Wreq::Client instance.
 #   All requests from this client will use the specified emulation unless overridden.
 client = Wreq::Client.new(emulation: Wreq::Emulation.new(
-  device: Wreq::EmulationDevice::Chrome142,
-  os: Wreq::EmulationOS::MacOS,
-  skip_http2: false,
-  skip_headers: false
+  profile: Wreq::Profile::Chrome142,
+  platform: Wreq::Platform::MacOS,
+  http2: true,
+  headers: true
 ))
 
 resp = client.get("https://tls.peet.ws/api/all")
@@ -26,10 +26,10 @@ puts resp.text
 resp = client.get(
   "https://tls.peet.ws/api/all",
   emulation: Wreq::Emulation.new(
-    device: Wreq::EmulationDevice::Safari26,
-    os: Wreq::EmulationOS::MacOS,
-    skip_http2: false,
-    skip_headers: false
+    profile: Wreq::Profile::Safari26,
+    platform: Wreq::Platform::MacOS,
+    http2: true,
+    headers: true
   ),
   # Skip client default headers for this request
   default_headers: false

--- a/lib/wreq_ruby/emulate.rb
+++ b/lib/wreq_ruby/emulate.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
 module Wreq
-  # Device emulation enumeration backed by Rust.
+  # Browser and client fingerprint profile enumeration backed by Rust.
   #
   # Variants are exposed as constants under this class.
-  # Each constant is an instance of {Wreq::EmulationDevice}.
+  # Each constant is an instance of {Wreq::Profile} and can be passed to
+  # {Wreq::Emulation.new} via the `profile:` keyword.
   #
-  # @example Using predefined constants
-  #   device = Wreq::EmulationDevice::Chrome117
-  #   device.class #=> Wreq::EmulationDevice
-  class EmulationDevice
+  # @example Using a predefined profile
+  #   profile = Wreq::Profile::Chrome117
+  #   profile.class #=> Wreq::Profile
+  #
+  # @example Applying a profile to emulation
+  #   emu = Wreq::Emulation.new(profile: Wreq::Profile::Chrome117)
+  class Profile
     # Constants are set by the native extension at initialization.
     # These stubs are for documentation only.
     unless const_defined?(:Chrome100)
@@ -141,22 +145,26 @@ module Wreq
     end
 
     unless method_defined?(:to_s)
-      # Returns a string representation of the emulation device.
-      # @return [String] Emulation device as string
+      # Returns the profile name.
+      # @return [String] Profile name as a string
       def to_s
       end
     end
   end
 
-  # Operating system emulation enumeration backed by Rust.
+  # Operating system platform enumeration backed by Rust.
   #
   # Variants are exposed as constants under this class.
-  # Each constant is an instance of {Wreq::EmulationOS}.
+  # Each constant is an instance of {Wreq::Platform} and can be passed to
+  # {Wreq::Emulation.new} via the `platform:` keyword.
   #
-  # @example Using predefined constants
-  #   os = Wreq::EmulationOS::Windows
-  #   os.class #=> Wreq::EmulationOS
-  class EmulationOS
+  # @example Using a predefined platform
+  #   platform = Wreq::Platform::Windows
+  #   platform.class #=> Wreq::Platform
+  #
+  # @example Applying a platform to emulation
+  #   emu = Wreq::Emulation.new(platform: Wreq::Platform::Windows)
+  class Platform
     # Constants are set by the native extension at initialization.
     # These stubs are for documentation only.
     unless const_defined?(:Windows)
@@ -168,8 +176,8 @@ module Wreq
     end
 
     unless method_defined?(:to_s)
-      # Returns a string representation of the emulation OS.
-      # @return [String] Emulation OS as string
+      # Returns the platform name.
+      # @return [String] Platform name as a string
       def to_s
       end
     end
@@ -177,26 +185,34 @@ module Wreq
 
   # Emulation option wrapper.
   #
-  # This class wraps device and OS emulation options and provides
-  # a unified interface for browser environment simulation.
-  # The actual implementation is provided by Rust for performance.
+  # This class combines a fingerprint `profile`, an OS `platform`, and toggles
+  # for HTTP/2 and automatic default headers. The actual implementation is
+  # provided by Rust.
+  #
+  # `profile:` defaults to the library's default profile when omitted.
+  # `platform:` defaults to the library's default platform when omitted.
   #
   # @example Create an emulation option
-  #   emu = Wreq::Emulation.new(device: Wreq::EmulationDevice::Chrome117, os: Wreq::EmulationOS::Windows)
+  #   emu = Wreq::Emulation.new(
+  #     profile: Wreq::Profile::Chrome117,
+  #     platform: Wreq::Platform::Windows,
+  #     http2: true,
+  #     headers: true
+  #   )
   #
-  # @param device [Wreq::EmulationDevice] Device profile (optional)
-  # @param os [Wreq::EmulationOS] Operating system profile (optional)
-  # @param skip_http2 [Boolean] Whether to skip HTTP/2 (optional)
-  # @param skip_headers [Boolean] Whether to skip default headers (optional)
+  # @param profile [Wreq::Profile, nil] Fingerprint profile to emulate
+  # @param platform [Wreq::Platform, nil] Operating system platform to emulate
+  # @param http2 [Boolean] Whether HTTP/2 support is enabled
+  # @param headers [Boolean] Whether default emulation headers are enabled
   class Emulation
     # Native fields and methods are set by the extension.
     # This stub is for documentation only.
     unless method_defined?(:new)
-      # @param device [Wreq::EmulationDevice] Device profile (optional)
-      # @param os [Wreq::EmulationOS] Operating system profile (optional)
-      # @param skip_http2 [Boolean] Whether to skip HTTP/2 (optional)
-      # @param skip_headers [Boolean] Whether to skip default headers (optional)
-      def self.new(device: nil, os: nil, skip_http2: false, skip_headers: false)
+      # @param profile [Wreq::Profile, nil] Fingerprint profile to emulate
+      # @param platform [Wreq::Platform, nil] Operating system platform to emulate
+      # @param http2 [Boolean] Whether HTTP/2 support is enabled
+      # @param headers [Boolean] Whether default emulation headers are enabled
+      def self.new(profile: nil, platform: nil, http2: true, headers: true)
       end
     end
   end

--- a/lib/wreq_ruby/http.rb
+++ b/lib/wreq_ruby/http.rb
@@ -134,13 +134,13 @@ end
 module Wreq
   class StatusCode
     def inspect
-      "#<Wreq::StatusCode #{to_s}>"
+      "#<Wreq::StatusCode #{self}>"
     end
   end
 
   class Version
     def inspect
-      "#<Wreq::Version #{to_s}>"
+      "#<Wreq::Version #{self}>"
     end
   end
 end

--- a/src/client.rs
+++ b/src/client.rs
@@ -83,7 +83,7 @@ struct Builder {
     /// Sets the maximum idle connection per host allowed in the pool.
     pool_max_idle_per_host: Option<usize>,
     /// Sets the maximum number of connections in the pool.
-    pool_max_size: Option<u32>,
+    pool_max_size: Option<usize>,
 
     // ========= Protocol options =========
     /// Whether to use the HTTP/1 protocol only.
@@ -286,7 +286,7 @@ impl Client {
                 apply_option!(set_if_some, builder, params.https_only, https_only);
 
                 // TLS options.
-                apply_option!(set_if_some, builder, params.verify, cert_verification);
+                apply_option!(set_if_some, builder, params.verify, tls_cert_verification);
 
                 // Network options.
                 apply_option!(set_if_some, builder, params.proxy, proxy);

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -4,11 +4,11 @@ use magnus::{
 };
 
 define_ruby_enum!(
-    /// An emulation.
+    /// An emulation profile.
     const,
-    EmulationDevice,
-    "Wreq::EmulationDevice",
-    wreq_util::Emulation,
+    Profile,
+    "Wreq::Profile",
+    wreq_util::Profile,
     Chrome100,
     Chrome101,
     Chrome104,
@@ -142,11 +142,11 @@ define_ruby_enum!(
 );
 
 define_ruby_enum!(
-    /// An emulation operating system.
+    /// An emulation profile for OS.
     const,
-    EmulationOS,
-    "Wreq::EmulationOS",
-    wreq_util::EmulationOS,
+    Platform,
+    "Wreq::Platform",
+    wreq_util::Platform,
     Windows,
     MacOS,
     Linux,
@@ -157,19 +157,19 @@ define_ruby_enum!(
 /// A struct to represent the `EmulationOption` class.
 #[derive(Clone)]
 #[magnus::wrap(class = "Wreq::Emulation", free_immediately, size)]
-pub struct Emulation(pub wreq_util::EmulationOption);
+pub struct Emulation(pub wreq_util::Emulation);
 
-// ===== impl EmulationDevice =====
+// ===== impl Profile =====
 
-impl EmulationDevice {
+impl Profile {
     pub fn to_s(&self) -> String {
         self.into_ffi().inspect()
     }
 }
 
-// ===== impl EmulationOS =====
+// ===== impl Platform =====
 
-impl EmulationOS {
+impl Platform {
     pub fn to_s(&self) -> String {
         self.into_ffi().inspect()
     }
@@ -181,29 +181,29 @@ impl Emulation {
     fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
         let mut device = None;
         let mut os = None;
-        let mut skip_http2 = None;
-        let mut skip_headers = None;
+        let mut http2 = None;
+        let mut headers = None;
 
         if let Some(hash) = args.first().and_then(|v| RHash::from_value(*v)) {
-            if let Some(v) = hash.get(ruby.to_symbol("device")) {
-                device = Some(Obj::<EmulationDevice>::try_convert(v)?);
+            if let Some(v) = hash.get(ruby.to_symbol(stringify!(profile))) {
+                device = Some(Obj::<Profile>::try_convert(v)?);
             }
-            if let Some(v) = hash.get(ruby.to_symbol("os")) {
-                os = Some(Obj::<EmulationOS>::try_convert(v)?);
+            if let Some(v) = hash.get(ruby.to_symbol(stringify!(platform))) {
+                os = Some(Obj::<Platform>::try_convert(v)?);
             }
-            if let Some(v) = hash.get(ruby.to_symbol("skip_http2")) {
-                skip_http2 = Some(bool::try_convert(v)?);
+            if let Some(v) = hash.get(ruby.to_symbol(stringify!(http2))) {
+                http2 = Some(bool::try_convert(v)?);
             }
-            if let Some(v) = hash.get(ruby.to_symbol("skip_headers")) {
-                skip_headers = Some(bool::try_convert(v)?);
+            if let Some(v) = hash.get(ruby.to_symbol(stringify!(headers))) {
+                headers = Some(bool::try_convert(v)?);
             }
         }
 
-        let emulation = wreq_util::EmulationOption::builder()
-            .emulation(device.map(|obj| obj.into_ffi()).unwrap_or_default())
-            .emulation_os(os.map(|os| os.into_ffi()).unwrap_or_default())
-            .skip_http2(skip_http2.unwrap_or(false))
-            .skip_headers(skip_headers.unwrap_or(false))
+        let emulation = wreq_util::Emulation::builder()
+            .profile(device.map(|obj| obj.into_ffi()).unwrap_or_default())
+            .platform(os.map(|os| os.into_ffi()).unwrap_or_default())
+            .http2(http2.unwrap_or(true))
+            .headers(headers.unwrap_or(true))
             .build();
 
         Ok(Self(emulation))
@@ -211,150 +211,150 @@ impl Emulation {
 }
 
 pub fn include(ruby: &Ruby, gem_module: &RModule) -> Result<(), Error> {
-    // EmulationDevice enum binding
-    let emulation_class = gem_module.define_class("EmulationDevice", ruby.class_object())?;
-    emulation_class.define_method("to_s", method!(EmulationDevice::to_s, 0))?;
-    emulation_class.const_set("Chrome100", EmulationDevice::Chrome100)?;
-    emulation_class.const_set("Chrome101", EmulationDevice::Chrome101)?;
-    emulation_class.const_set("Chrome104", EmulationDevice::Chrome104)?;
-    emulation_class.const_set("Chrome105", EmulationDevice::Chrome105)?;
-    emulation_class.const_set("Chrome106", EmulationDevice::Chrome106)?;
-    emulation_class.const_set("Chrome107", EmulationDevice::Chrome107)?;
-    emulation_class.const_set("Chrome108", EmulationDevice::Chrome108)?;
-    emulation_class.const_set("Chrome109", EmulationDevice::Chrome109)?;
-    emulation_class.const_set("Chrome110", EmulationDevice::Chrome110)?;
-    emulation_class.const_set("Chrome114", EmulationDevice::Chrome114)?;
-    emulation_class.const_set("Chrome116", EmulationDevice::Chrome116)?;
-    emulation_class.const_set("Chrome117", EmulationDevice::Chrome117)?;
-    emulation_class.const_set("Chrome118", EmulationDevice::Chrome118)?;
-    emulation_class.const_set("Chrome119", EmulationDevice::Chrome119)?;
-    emulation_class.const_set("Chrome120", EmulationDevice::Chrome120)?;
-    emulation_class.const_set("Chrome123", EmulationDevice::Chrome123)?;
-    emulation_class.const_set("Chrome124", EmulationDevice::Chrome124)?;
-    emulation_class.const_set("Chrome126", EmulationDevice::Chrome126)?;
-    emulation_class.const_set("Chrome127", EmulationDevice::Chrome127)?;
-    emulation_class.const_set("Chrome128", EmulationDevice::Chrome128)?;
-    emulation_class.const_set("Chrome129", EmulationDevice::Chrome129)?;
-    emulation_class.const_set("Chrome130", EmulationDevice::Chrome130)?;
-    emulation_class.const_set("Chrome131", EmulationDevice::Chrome131)?;
-    emulation_class.const_set("Chrome132", EmulationDevice::Chrome132)?;
-    emulation_class.const_set("Chrome133", EmulationDevice::Chrome133)?;
-    emulation_class.const_set("Chrome134", EmulationDevice::Chrome134)?;
-    emulation_class.const_set("Chrome135", EmulationDevice::Chrome135)?;
-    emulation_class.const_set("Chrome136", EmulationDevice::Chrome136)?;
-    emulation_class.const_set("Chrome137", EmulationDevice::Chrome137)?;
-    emulation_class.const_set("Chrome138", EmulationDevice::Chrome138)?;
-    emulation_class.const_set("Chrome139", EmulationDevice::Chrome139)?;
-    emulation_class.const_set("Chrome140", EmulationDevice::Chrome140)?;
-    emulation_class.const_set("Chrome141", EmulationDevice::Chrome141)?;
-    emulation_class.const_set("Chrome142", EmulationDevice::Chrome142)?;
-    emulation_class.const_set("Chrome143", EmulationDevice::Chrome143)?;
-    emulation_class.const_set("Chrome144", EmulationDevice::Chrome144)?;
-    emulation_class.const_set("Chrome145", EmulationDevice::Chrome145)?;
-    emulation_class.const_set("Chrome146", EmulationDevice::Chrome146)?;
-    emulation_class.const_set("Chrome147", EmulationDevice::Chrome147)?;
-    emulation_class.const_set("Edge101", EmulationDevice::Edge101)?;
-    emulation_class.const_set("Edge122", EmulationDevice::Edge122)?;
-    emulation_class.const_set("Edge127", EmulationDevice::Edge127)?;
-    emulation_class.const_set("Edge131", EmulationDevice::Edge131)?;
-    emulation_class.const_set("Edge134", EmulationDevice::Edge134)?;
-    emulation_class.const_set("Edge135", EmulationDevice::Edge135)?;
-    emulation_class.const_set("Edge136", EmulationDevice::Edge136)?;
-    emulation_class.const_set("Edge137", EmulationDevice::Edge137)?;
-    emulation_class.const_set("Edge138", EmulationDevice::Edge138)?;
-    emulation_class.const_set("Edge139", EmulationDevice::Edge139)?;
-    emulation_class.const_set("Edge140", EmulationDevice::Edge140)?;
-    emulation_class.const_set("Edge141", EmulationDevice::Edge141)?;
-    emulation_class.const_set("Edge142", EmulationDevice::Edge142)?;
-    emulation_class.const_set("Edge143", EmulationDevice::Edge143)?;
-    emulation_class.const_set("Edge144", EmulationDevice::Edge144)?;
-    emulation_class.const_set("Edge145", EmulationDevice::Edge145)?;
-    emulation_class.const_set("Edge146", EmulationDevice::Edge146)?;
-    emulation_class.const_set("Edge147", EmulationDevice::Edge147)?;
+    // Profile enum binding
+    let profile = gem_module.define_class("Profile", ruby.class_object())?;
+    profile.define_method("to_s", method!(Profile::to_s, 0))?;
+    profile.const_set("Chrome100", Profile::Chrome100)?;
+    profile.const_set("Chrome101", Profile::Chrome101)?;
+    profile.const_set("Chrome104", Profile::Chrome104)?;
+    profile.const_set("Chrome105", Profile::Chrome105)?;
+    profile.const_set("Chrome106", Profile::Chrome106)?;
+    profile.const_set("Chrome107", Profile::Chrome107)?;
+    profile.const_set("Chrome108", Profile::Chrome108)?;
+    profile.const_set("Chrome109", Profile::Chrome109)?;
+    profile.const_set("Chrome110", Profile::Chrome110)?;
+    profile.const_set("Chrome114", Profile::Chrome114)?;
+    profile.const_set("Chrome116", Profile::Chrome116)?;
+    profile.const_set("Chrome117", Profile::Chrome117)?;
+    profile.const_set("Chrome118", Profile::Chrome118)?;
+    profile.const_set("Chrome119", Profile::Chrome119)?;
+    profile.const_set("Chrome120", Profile::Chrome120)?;
+    profile.const_set("Chrome123", Profile::Chrome123)?;
+    profile.const_set("Chrome124", Profile::Chrome124)?;
+    profile.const_set("Chrome126", Profile::Chrome126)?;
+    profile.const_set("Chrome127", Profile::Chrome127)?;
+    profile.const_set("Chrome128", Profile::Chrome128)?;
+    profile.const_set("Chrome129", Profile::Chrome129)?;
+    profile.const_set("Chrome130", Profile::Chrome130)?;
+    profile.const_set("Chrome131", Profile::Chrome131)?;
+    profile.const_set("Chrome132", Profile::Chrome132)?;
+    profile.const_set("Chrome133", Profile::Chrome133)?;
+    profile.const_set("Chrome134", Profile::Chrome134)?;
+    profile.const_set("Chrome135", Profile::Chrome135)?;
+    profile.const_set("Chrome136", Profile::Chrome136)?;
+    profile.const_set("Chrome137", Profile::Chrome137)?;
+    profile.const_set("Chrome138", Profile::Chrome138)?;
+    profile.const_set("Chrome139", Profile::Chrome139)?;
+    profile.const_set("Chrome140", Profile::Chrome140)?;
+    profile.const_set("Chrome141", Profile::Chrome141)?;
+    profile.const_set("Chrome142", Profile::Chrome142)?;
+    profile.const_set("Chrome143", Profile::Chrome143)?;
+    profile.const_set("Chrome144", Profile::Chrome144)?;
+    profile.const_set("Chrome145", Profile::Chrome145)?;
+    profile.const_set("Chrome146", Profile::Chrome146)?;
+    profile.const_set("Chrome147", Profile::Chrome147)?;
+    profile.const_set("Edge101", Profile::Edge101)?;
+    profile.const_set("Edge122", Profile::Edge122)?;
+    profile.const_set("Edge127", Profile::Edge127)?;
+    profile.const_set("Edge131", Profile::Edge131)?;
+    profile.const_set("Edge134", Profile::Edge134)?;
+    profile.const_set("Edge135", Profile::Edge135)?;
+    profile.const_set("Edge136", Profile::Edge136)?;
+    profile.const_set("Edge137", Profile::Edge137)?;
+    profile.const_set("Edge138", Profile::Edge138)?;
+    profile.const_set("Edge139", Profile::Edge139)?;
+    profile.const_set("Edge140", Profile::Edge140)?;
+    profile.const_set("Edge141", Profile::Edge141)?;
+    profile.const_set("Edge142", Profile::Edge142)?;
+    profile.const_set("Edge143", Profile::Edge143)?;
+    profile.const_set("Edge144", Profile::Edge144)?;
+    profile.const_set("Edge145", Profile::Edge145)?;
+    profile.const_set("Edge146", Profile::Edge146)?;
+    profile.const_set("Edge147", Profile::Edge147)?;
 
-    emulation_class.const_set("Firefox109", EmulationDevice::Firefox109)?;
-    emulation_class.const_set("Firefox117", EmulationDevice::Firefox117)?;
-    emulation_class.const_set("Firefox128", EmulationDevice::Firefox128)?;
-    emulation_class.const_set("Firefox133", EmulationDevice::Firefox133)?;
-    emulation_class.const_set("Firefox135", EmulationDevice::Firefox135)?;
-    emulation_class.const_set("FirefoxPrivate135", EmulationDevice::FirefoxPrivate135)?;
-    emulation_class.const_set("FirefoxAndroid135", EmulationDevice::FirefoxAndroid135)?;
-    emulation_class.const_set("Firefox136", EmulationDevice::Firefox136)?;
-    emulation_class.const_set("FirefoxPrivate136", EmulationDevice::FirefoxPrivate136)?;
-    emulation_class.const_set("Firefox139", EmulationDevice::Firefox139)?;
-    emulation_class.const_set("Firefox142", EmulationDevice::Firefox142)?;
-    emulation_class.const_set("Firefox143", EmulationDevice::Firefox143)?;
-    emulation_class.const_set("Firefox144", EmulationDevice::Firefox144)?;
-    emulation_class.const_set("Firefox145", EmulationDevice::Firefox145)?;
-    emulation_class.const_set("Firefox146", EmulationDevice::Firefox146)?;
-    emulation_class.const_set("Firefox147", EmulationDevice::Firefox147)?;
-    emulation_class.const_set("Firefox148", EmulationDevice::Firefox148)?;
-    emulation_class.const_set("Firefox149", EmulationDevice::Firefox149)?;
+    profile.const_set("Firefox109", Profile::Firefox109)?;
+    profile.const_set("Firefox117", Profile::Firefox117)?;
+    profile.const_set("Firefox128", Profile::Firefox128)?;
+    profile.const_set("Firefox133", Profile::Firefox133)?;
+    profile.const_set("Firefox135", Profile::Firefox135)?;
+    profile.const_set("FirefoxPrivate135", Profile::FirefoxPrivate135)?;
+    profile.const_set("FirefoxAndroid135", Profile::FirefoxAndroid135)?;
+    profile.const_set("Firefox136", Profile::Firefox136)?;
+    profile.const_set("FirefoxPrivate136", Profile::FirefoxPrivate136)?;
+    profile.const_set("Firefox139", Profile::Firefox139)?;
+    profile.const_set("Firefox142", Profile::Firefox142)?;
+    profile.const_set("Firefox143", Profile::Firefox143)?;
+    profile.const_set("Firefox144", Profile::Firefox144)?;
+    profile.const_set("Firefox145", Profile::Firefox145)?;
+    profile.const_set("Firefox146", Profile::Firefox146)?;
+    profile.const_set("Firefox147", Profile::Firefox147)?;
+    profile.const_set("Firefox148", Profile::Firefox148)?;
+    profile.const_set("Firefox149", Profile::Firefox149)?;
 
-    emulation_class.const_set("SafariIos17_2", EmulationDevice::SafariIos17_2)?;
-    emulation_class.const_set("SafariIos17_4_1", EmulationDevice::SafariIos17_4_1)?;
-    emulation_class.const_set("SafariIos16_5", EmulationDevice::SafariIos16_5)?;
-    emulation_class.const_set("Safari15_3", EmulationDevice::Safari15_3)?;
-    emulation_class.const_set("Safari15_5", EmulationDevice::Safari15_5)?;
-    emulation_class.const_set("Safari15_6_1", EmulationDevice::Safari15_6_1)?;
-    emulation_class.const_set("Safari16", EmulationDevice::Safari16)?;
-    emulation_class.const_set("Safari16_5", EmulationDevice::Safari16_5)?;
-    emulation_class.const_set("Safari17_0", EmulationDevice::Safari17_0)?;
-    emulation_class.const_set("Safari17_2_1", EmulationDevice::Safari17_2_1)?;
-    emulation_class.const_set("Safari17_4_1", EmulationDevice::Safari17_4_1)?;
-    emulation_class.const_set("Safari17_5", EmulationDevice::Safari17_5)?;
-    emulation_class.const_set("Safari17_6", EmulationDevice::Safari17_6)?;
-    emulation_class.const_set("Safari18", EmulationDevice::Safari18)?;
-    emulation_class.const_set("SafariIPad18", EmulationDevice::SafariIPad18)?;
-    emulation_class.const_set("Safari18_2", EmulationDevice::Safari18_2)?;
-    emulation_class.const_set("Safari18_3", EmulationDevice::Safari18_3)?;
-    emulation_class.const_set("Safari18_3_1", EmulationDevice::Safari18_3_1)?;
-    emulation_class.const_set("SafariIos18_1_1", EmulationDevice::SafariIos18_1_1)?;
-    emulation_class.const_set("Safari18_5", EmulationDevice::Safari18_5)?;
-    emulation_class.const_set("Safari26", EmulationDevice::Safari26)?;
-    emulation_class.const_set("Safari26_1", EmulationDevice::Safari26_1)?;
-    emulation_class.const_set("Safari26_2", EmulationDevice::Safari26_2)?;
-    emulation_class.const_set("SafariIos26", EmulationDevice::SafariIos26)?;
-    emulation_class.const_set("SafariIos26_2", EmulationDevice::SafariIos26_2)?;
-    emulation_class.const_set("SafariIPad26", EmulationDevice::SafariIPad26)?;
-    emulation_class.const_set("SafariIpad26_2", EmulationDevice::SafariIpad26_2)?;
+    profile.const_set("SafariIos17_2", Profile::SafariIos17_2)?;
+    profile.const_set("SafariIos17_4_1", Profile::SafariIos17_4_1)?;
+    profile.const_set("SafariIos16_5", Profile::SafariIos16_5)?;
+    profile.const_set("Safari15_3", Profile::Safari15_3)?;
+    profile.const_set("Safari15_5", Profile::Safari15_5)?;
+    profile.const_set("Safari15_6_1", Profile::Safari15_6_1)?;
+    profile.const_set("Safari16", Profile::Safari16)?;
+    profile.const_set("Safari16_5", Profile::Safari16_5)?;
+    profile.const_set("Safari17_0", Profile::Safari17_0)?;
+    profile.const_set("Safari17_2_1", Profile::Safari17_2_1)?;
+    profile.const_set("Safari17_4_1", Profile::Safari17_4_1)?;
+    profile.const_set("Safari17_5", Profile::Safari17_5)?;
+    profile.const_set("Safari17_6", Profile::Safari17_6)?;
+    profile.const_set("Safari18", Profile::Safari18)?;
+    profile.const_set("SafariIPad18", Profile::SafariIPad18)?;
+    profile.const_set("Safari18_2", Profile::Safari18_2)?;
+    profile.const_set("Safari18_3", Profile::Safari18_3)?;
+    profile.const_set("Safari18_3_1", Profile::Safari18_3_1)?;
+    profile.const_set("SafariIos18_1_1", Profile::SafariIos18_1_1)?;
+    profile.const_set("Safari18_5", Profile::Safari18_5)?;
+    profile.const_set("Safari26", Profile::Safari26)?;
+    profile.const_set("Safari26_1", Profile::Safari26_1)?;
+    profile.const_set("Safari26_2", Profile::Safari26_2)?;
+    profile.const_set("SafariIos26", Profile::SafariIos26)?;
+    profile.const_set("SafariIos26_2", Profile::SafariIos26_2)?;
+    profile.const_set("SafariIPad26", Profile::SafariIPad26)?;
+    profile.const_set("SafariIpad26_2", Profile::SafariIpad26_2)?;
 
-    emulation_class.const_set("OkHttp3_9", EmulationDevice::OkHttp3_9)?;
-    emulation_class.const_set("OkHttp3_11", EmulationDevice::OkHttp3_11)?;
-    emulation_class.const_set("OkHttp3_13", EmulationDevice::OkHttp3_13)?;
-    emulation_class.const_set("OkHttp3_14", EmulationDevice::OkHttp3_14)?;
-    emulation_class.const_set("OkHttp4_9", EmulationDevice::OkHttp4_9)?;
-    emulation_class.const_set("OkHttp4_10", EmulationDevice::OkHttp4_10)?;
-    emulation_class.const_set("OkHttp4_12", EmulationDevice::OkHttp4_12)?;
-    emulation_class.const_set("OkHttp5", EmulationDevice::OkHttp5)?;
+    profile.const_set("OkHttp3_9", Profile::OkHttp3_9)?;
+    profile.const_set("OkHttp3_11", Profile::OkHttp3_11)?;
+    profile.const_set("OkHttp3_13", Profile::OkHttp3_13)?;
+    profile.const_set("OkHttp3_14", Profile::OkHttp3_14)?;
+    profile.const_set("OkHttp4_9", Profile::OkHttp4_9)?;
+    profile.const_set("OkHttp4_10", Profile::OkHttp4_10)?;
+    profile.const_set("OkHttp4_12", Profile::OkHttp4_12)?;
+    profile.const_set("OkHttp5", Profile::OkHttp5)?;
 
-    emulation_class.const_set("Opera116", EmulationDevice::Opera116)?;
-    emulation_class.const_set("Opera117", EmulationDevice::Opera117)?;
-    emulation_class.const_set("Opera118", EmulationDevice::Opera118)?;
-    emulation_class.const_set("Opera119", EmulationDevice::Opera119)?;
-    emulation_class.const_set("Opera120", EmulationDevice::Opera120)?;
-    emulation_class.const_set("Opera121", EmulationDevice::Opera121)?;
-    emulation_class.const_set("Opera122", EmulationDevice::Opera122)?;
-    emulation_class.const_set("Opera123", EmulationDevice::Opera123)?;
-    emulation_class.const_set("Opera124", EmulationDevice::Opera124)?;
-    emulation_class.const_set("Opera125", EmulationDevice::Opera125)?;
-    emulation_class.const_set("Opera126", EmulationDevice::Opera126)?;
-    emulation_class.const_set("Opera127", EmulationDevice::Opera127)?;
-    emulation_class.const_set("Opera128", EmulationDevice::Opera128)?;
-    emulation_class.const_set("Opera129", EmulationDevice::Opera129)?;
-    emulation_class.const_set("Opera130", EmulationDevice::Opera130)?;
+    profile.const_set("Opera116", Profile::Opera116)?;
+    profile.const_set("Opera117", Profile::Opera117)?;
+    profile.const_set("Opera118", Profile::Opera118)?;
+    profile.const_set("Opera119", Profile::Opera119)?;
+    profile.const_set("Opera120", Profile::Opera120)?;
+    profile.const_set("Opera121", Profile::Opera121)?;
+    profile.const_set("Opera122", Profile::Opera122)?;
+    profile.const_set("Opera123", Profile::Opera123)?;
+    profile.const_set("Opera124", Profile::Opera124)?;
+    profile.const_set("Opera125", Profile::Opera125)?;
+    profile.const_set("Opera126", Profile::Opera126)?;
+    profile.const_set("Opera127", Profile::Opera127)?;
+    profile.const_set("Opera128", Profile::Opera128)?;
+    profile.const_set("Opera129", Profile::Opera129)?;
+    profile.const_set("Opera130", Profile::Opera130)?;
 
-    // EmulationOS enum binding
-    let emulation_os_class = gem_module.define_class("EmulationOS", ruby.class_object())?;
-    emulation_os_class.define_method("to_s", method!(EmulationOS::to_s, 0))?;
-    emulation_os_class.const_set("Windows", EmulationOS::Windows)?;
-    emulation_os_class.const_set("MacOS", EmulationOS::MacOS)?;
-    emulation_os_class.const_set("Linux", EmulationOS::Linux)?;
-    emulation_os_class.const_set("Android", EmulationOS::Android)?;
-    emulation_os_class.const_set("IOS", EmulationOS::IOS)?;
+    // Platform enum binding
+    let platform = gem_module.define_class("Platform", ruby.class_object())?;
+    platform.define_method("to_s", method!(Platform::to_s, 0))?;
+    platform.const_set("Windows", Platform::Windows)?;
+    platform.const_set("MacOS", Platform::MacOS)?;
+    platform.const_set("Linux", Platform::Linux)?;
+    platform.const_set("Android", Platform::Android)?;
+    platform.const_set("IOS", Platform::IOS)?;
 
     // Emulation class binding
-    let emulation_option_class = gem_module.define_class("Emulation", ruby.class_object())?;
-    emulation_option_class.define_singleton_method("new", function!(Emulation::new, -1))?;
+    let emulation = gem_module.define_class("Emulation", ruby.class_object())?;
+    emulation.define_singleton_method("new", function!(Emulation::new, -1))?;
     Ok(())
 }

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -179,17 +179,17 @@ impl Platform {
 
 impl Emulation {
     fn new(ruby: &Ruby, args: &[Value]) -> Result<Self, Error> {
-        let mut device = None;
-        let mut os = None;
+        let mut profile = None;
+        let mut platform = None;
         let mut http2 = None;
         let mut headers = None;
 
         if let Some(hash) = args.first().and_then(|v| RHash::from_value(*v)) {
             if let Some(v) = hash.get(ruby.to_symbol(stringify!(profile))) {
-                device = Some(Obj::<Profile>::try_convert(v)?);
+                profile = Some(Obj::<Profile>::try_convert(v)?);
             }
             if let Some(v) = hash.get(ruby.to_symbol(stringify!(platform))) {
-                os = Some(Obj::<Platform>::try_convert(v)?);
+                platform = Some(Obj::<Platform>::try_convert(v)?);
             }
             if let Some(v) = hash.get(ruby.to_symbol(stringify!(http2))) {
                 http2 = Some(bool::try_convert(v)?);
@@ -200,8 +200,8 @@ impl Emulation {
         }
 
         let emulation = wreq_util::Emulation::builder()
-            .profile(device.map(|obj| obj.into_ffi()).unwrap_or_default())
-            .platform(os.map(|os| os.into_ffi()).unwrap_or_default())
+            .profile(profile.map(|obj| obj.into_ffi()).unwrap_or_default())
+            .platform(platform.map(|os| os.into_ffi()).unwrap_or_default())
             .http2(http2.unwrap_or(true))
             .headers(headers.unwrap_or(true))
             .build();

--- a/test/emulation_test.rb
+++ b/test/emulation_test.rb
@@ -4,18 +4,18 @@ require "test_helper"
 
 class EmulationTest < Minitest::Test
   def test_all_emulation_device_constants_are_non_nil
-    Wreq::EmulationDevice.constants.each do |name|
-      const = Wreq::EmulationDevice.const_get(name)
-      assert_instance_of Wreq::EmulationDevice, const,
-        "#{name} should be EmulationDevice, got #{const.inspect}"
+    Wreq::Profile.constants.each do |name|
+      const = Wreq::Profile.const_get(name)
+      assert_instance_of Wreq::Profile, const,
+        "#{name} should be Profile, got #{const.inspect}"
     end
   end
 
   def test_all_emulation_os_constants_are_non_nil
-    Wreq::EmulationOS.constants.each do |name|
-      const = Wreq::EmulationOS.const_get(name)
-      assert_instance_of Wreq::EmulationOS, const,
-        "#{name} should be EmulationOS, got #{const.inspect}"
+    Wreq::Platform.constants.each do |name|
+      const = Wreq::Platform.const_get(name)
+      assert_instance_of Wreq::Platform, const,
+        "#{name} should be Platform, got #{const.inspect}"
     end
   end
 end


### PR DESCRIPTION
This breaking update renames several APIs under Emulation.