### PR TITLE
build(deps): update `http` dependency version to 1.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ indexmap = { version = "2.14.0", features = ["serde"] }
 cookie = "0.18.1"
 bytes = "1.11.1"
 arc-swap = "1.9.1"
-http = "1.4.0"
+http = "1.4.1"
 http-body-util = "0.1.3"
 futures-util = { version = "0.3.32", default-features = false }
 


### PR DESCRIPTION
It’s a nitpicky bump. The version is already pinned to 1.4.1 in Cargo.lock, but this prevents unexpected issues.

https://github.com/hyperium/http/releases/tag/v1.4.1