### PR TITLE
fix: ruby macro undefined issue

### DIFF
--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -35,13 +35,13 @@ impl SameSite {
     }
 
     /// SameSite attribute as a lowercase Ruby symbol.
-    pub fn to_sym(&self) -> magnus::Symbol {
-        let name = match self {
+    pub fn to_sym(ruby: &Ruby, rb_self: &Self) -> magnus::Symbol {
+        let name = match *rb_self {
             SameSite::Strict => "strict",
             SameSite::Lax => "lax",
             SameSite::None => "none",
         };
-        Ruby::get().unwrap().to_symbol(name)
+        ruby.to_symbol(name)
     }
 }
 

--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -41,7 +41,7 @@ impl SameSite {
             SameSite::Lax => "lax",
             SameSite::None => "none",
         };
-        ruby!().to_symbol(name)
+        Ruby::get().unwrap().to_symbol(name)
     }
 }
 

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -220,15 +220,15 @@ impl Platform {
         self.into_ffi().inspect()
     }
 
-    pub fn to_sym(&self) -> magnus::Symbol {
-        let name = match self {
+    pub fn to_sym(ruby: &Ruby, rb_self: &Self) -> magnus::Symbol {
+        let name = match *rb_self {
             Platform::Windows => "windows",
             Platform::MacOS => "macos",
             Platform::Linux => "linux",
             Platform::Android => "android",
             Platform::IOS => "ios",
         };
-        Ruby::get().unwrap().to_symbol(name)
+        ruby.to_symbol(name)
     }
 }
 

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -228,7 +228,7 @@ impl Platform {
             Platform::Android => "android",
             Platform::IOS => "ios",
         };
-        ruby!().to_symbol(name)
+        Ruby::get().unwrap().to_symbol(name)
     }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -46,8 +46,8 @@ impl Method {
 
     /// HTTP method as a lowercase Ruby symbol.
     #[inline]
-    pub fn to_sym(&self) -> magnus::Symbol {
-        let name = match self {
+    pub fn to_sym(ruby: &Ruby, rb_self: &Self) -> magnus::Symbol {
+        let name = match *rb_self {
             Method::GET => "get",
             Method::HEAD => "head",
             Method::POST => "post",
@@ -57,7 +57,7 @@ impl Method {
             Method::TRACE => "trace",
             Method::PATCH => "patch",
         };
-        Ruby::get().unwrap().to_symbol(name)
+        ruby.to_symbol(name)
     }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -57,7 +57,7 @@ impl Method {
             Method::TRACE => "trace",
             Method::PATCH => "patch",
         };
-        ruby!().to_symbol(name)
+        Ruby::get().unwrap().to_symbol(name)
     }
 }
 


### PR DESCRIPTION
Related to a recent change that went in https://github.com/SearchApi/wreq-ruby/pull/139