### PR TITLE
feat(error): stabilize error classification priority

### DIFF
--- a/examples/error.rb
+++ b/examples/error.rb
@@ -6,7 +6,7 @@ begin
   Wreq.get("not-a-valid-url")
 rescue Wreq::Error => error
   puts "#{error.class}: #{error.message}"
-  puts "builder: #{error.is_builder}"
+  puts "builder: #{error.builder?}"
   puts "uri: #{error.uri.inspect}"
   puts "status: #{error.status.inspect}"
 end

--- a/lib/wreq_ruby/error.rb
+++ b/lib/wreq_ruby/error.rb
@@ -12,10 +12,10 @@ unless defined?(Wreq)
     #
     # A native kind such as BodyError, TlsError, or StatusError takes precedence
     # over details found in its cause chain. Native request errors are then
-    # classified as connection reset, timeout, proxy connection, destination
-    # connection, or RequestError, in that order. Use the predicates when code
-    # needs every native classification. Errors created by the binding itself
-    # return false for all of them.
+    # classified as connection reset, timeout, proxy connect failure,
+    # destination connect failure, or RequestError, in that order. Use the
+    # predicates when code needs every native classification. Errors created by
+    # the binding itself return false for all of them.
     #
     # @example Rescue any wreq-ruby runtime error
     #   begin
@@ -65,12 +65,14 @@ unless defined?(Wreq)
       def request?
       end
 
-      # @return [Boolean] Whether the native error is related to connecting
-      def connection?
+      # @return [Boolean] Whether the native error occurred while acquiring a
+      #   connection to the destination
+      def connect?
       end
 
-      # @return [Boolean] Whether the native error is related to a proxy connection
-      def proxy_connection?
+      # @return [Boolean] Whether the native error occurred while connecting
+      #   through a proxy
+      def proxy_connect?
       end
 
       # @return [Boolean] Whether the native error is a connection reset
@@ -136,10 +138,11 @@ unless defined?(Wreq)
     # @see https://github.com/SearchApi/wreq-ruby/blob/main/docs/fork-safety.md
     class ForkError < Error; end
 
-    # Raised when the client cannot connect to the destination server.
+    # Raised when the client cannot acquire a usable connection to the
+    # destination server.
     #
     # If the native error reports both a destination connection failure and a
-    # timeout, Wreq::TimeoutError is raised and `connection?` remains true. A
+    # timeout, Wreq::TimeoutError is raised and `connect?` remains true. A
     # system proxy or VPN that accepts the connection but never responds may
     # instead appear as a general request timeout.
     #
@@ -147,15 +150,17 @@ unless defined?(Wreq)
     #   client = Wreq::Client.new(no_proxy: true)
     #   begin
     #     client.get("http://127.0.0.1:1")
-    #   rescue Wreq::ConnectionError => error
+    #   rescue Wreq::ConnectError => error
     #     warn "connection failed: #{error.message}"
     #   end
-    class ConnectionError < Error; end
+    class ConnectError < Error; end
 
-    # Raised when the client cannot connect to the configured proxy.
+    # Raised when the client cannot establish a connection through the
+    # configured proxy. This includes failures while connecting to the proxy or
+    # negotiating a proxy tunnel.
     #
     # If the native error reports both a proxy connection failure and a timeout,
-    # Wreq::TimeoutError is raised and `proxy_connection?` remains true.
+    # Wreq::TimeoutError is raised and `proxy_connect?` remains true.
     #
     # @example Handle a proxy connection failure
     #   begin
@@ -163,10 +168,10 @@ unless defined?(Wreq)
     #       "https://example.com",
     #       proxy: "http://127.0.0.1:1"
     #     )
-    #   rescue Wreq::ProxyConnectionError => error
+    #   rescue Wreq::ProxyConnectError => error
     #     warn "proxy connection failed: #{error.message}"
     #   end
-    class ProxyConnectionError < Error; end
+    class ProxyConnectError < Error; end
 
     # Raised when a peer resets the connection.
     #
@@ -186,14 +191,14 @@ unless defined?(Wreq)
     # The current Ruby API does not expose certificate or identity inputs that
     # can deliberately trigger this error. TLS handshake and certificate
     # verification failures happen while connecting and normally raise
-    # Wreq::ConnectionError instead.
+    # Wreq::ConnectError instead.
     #
     # @example Distinguish TLS setup errors from connection errors
     #   begin
     #     Wreq::Client.new(verify: true).get("https://example.com")
     #   rescue Wreq::TlsError => error
     #     warn "TLS setup failed: #{error.message}"
-    #   rescue Wreq::ConnectionError => error
+    #   rescue Wreq::ConnectError => error
     #     warn "TLS connection failed: #{error.message}"
     #   end
     class TlsError < Error; end
@@ -241,10 +246,9 @@ unless defined?(Wreq)
 
     # Raised when a request operation exceeds its timeout.
     #
-    # This includes destination and proxy connection timeouts when the native
-    # error reports them as timeouts. Check `connection?` or `proxy_connection?`
-    # to see whether the native error also identifies that phase. `request?`
-    # can be true on the same error.
+    # This includes timeouts while connecting to the destination or proxy. Check
+    # `connect?` or `proxy_connect?` to see whether the native error also
+    # identifies the connect phase. `request?` can be true on the same error.
     #
     # @example Handle a request timeout
     #   client = Wreq::Client.new(timeout: 1)

--- a/lib/wreq_ruby/error.rb
+++ b/lib/wreq_ruby/error.rb
@@ -5,10 +5,10 @@ unless defined?(Wreq)
     # Base class for wreq-ruby runtime errors.
     #
     # Error remains a RuntimeError so existing rescue handlers keep working.
-    # Its subclass records one error category. The `is_*` methods preserve every
-    # predicate reported by the native `wreq::Error`, so more than one can be
-    # true. For example, a request timeout raises TimeoutError while both
-    # `is_timeout` and `is_request` are true.
+    # Its subclass records one primary category. Predicate methods retain every
+    # classification reported by the native `wreq::Error`, so more than one can
+    # be true. For example, a request timeout raises TimeoutError while both
+    # `timeout?` and `request?` return true.
     #
     # A native kind such as BodyError, TlsError, or StatusError takes precedence
     # over details found in its cause chain. Native request errors are then
@@ -22,7 +22,7 @@ unless defined?(Wreq)
     #     Wreq.get("not-a-valid-url")
     #   rescue Wreq::Error => error
     #     warn "#{error.class}: #{error.message}"
-    #     warn "invalid request" if error.is_builder
+    #     warn "invalid request" if error.builder?
     #   end
     class Error < RuntimeError
       # Get the URI recorded by the native error.
@@ -40,57 +40,57 @@ unless defined?(Wreq)
       attr_reader :status
 
       # @return [Boolean] Whether the native error came from a builder
-      def is_builder
+      def builder?
       end
 
       # @return [Boolean] Whether the native error came from redirect handling
-      def is_redirect
+      def redirect?
       end
 
       # @return [Boolean] Whether the native error represents an HTTP status
-      def is_status
+      def status?
       end
 
       # A request timeout uses TimeoutError even when this is also a connection
       # or proxy connection error.
       #
       # @return [Boolean] Whether the native error is related to a timeout
-      def is_timeout
+      def timeout?
       end
 
       # This may be true on connection and timeout subclasses because those
       # errors occur while sending a request.
       #
       # @return [Boolean] Whether the native error is related to a request
-      def is_request
+      def request?
       end
 
       # @return [Boolean] Whether the native error is related to connecting
-      def is_connect
+      def connection?
       end
 
       # @return [Boolean] Whether the native error is related to a proxy connection
-      def is_proxy_connect
+      def proxy_connection?
       end
 
       # @return [Boolean] Whether the native error is a connection reset
-      def is_connection_reset
+      def connection_reset?
       end
 
       # @return [Boolean] Whether the native error is related to a body
-      def is_body
+      def body?
       end
 
       # @return [Boolean] Whether the native error is related to TLS
-      def is_tls
+      def tls?
       end
 
       # @return [Boolean] Whether the native error is related to decoding
-      def is_decode
+      def decoding?
       end
 
       # @return [Boolean] Whether the native error is related to an upgrade
-      def is_upgrade
+      def upgrade?
       end
     end
 
@@ -139,7 +139,7 @@ unless defined?(Wreq)
     # Raised when the client cannot connect to the destination server.
     #
     # If the native error reports both a destination connection failure and a
-    # timeout, Wreq::TimeoutError is raised and `is_connect` remains true. A
+    # timeout, Wreq::TimeoutError is raised and `connection?` remains true. A
     # system proxy or VPN that accepts the connection but never responds may
     # instead appear as a general request timeout.
     #
@@ -155,7 +155,7 @@ unless defined?(Wreq)
     # Raised when the client cannot connect to the configured proxy.
     #
     # If the native error reports both a proxy connection failure and a timeout,
-    # Wreq::TimeoutError is raised and `is_proxy_connect` remains true.
+    # Wreq::TimeoutError is raised and `proxy_connection?` remains true.
     #
     # @example Handle a proxy connection failure
     #   begin
@@ -242,8 +242,8 @@ unless defined?(Wreq)
     # Raised when a request operation exceeds its timeout.
     #
     # This includes destination and proxy connection timeouts when the native
-    # error reports them as timeouts. Check `is_connect` or `is_proxy_connect`
-    # to see whether the native error also identifies that phase. `is_request`
+    # error reports them as timeouts. Check `connection?` or `proxy_connection?`
+    # to see whether the native error also identifies that phase. `request?`
     # can be true on the same error.
     #
     # @example Handle a request timeout

--- a/lib/wreq_ruby/error.rb
+++ b/lib/wreq_ruby/error.rb
@@ -5,9 +5,17 @@ unless defined?(Wreq)
     # Base class for wreq-ruby runtime errors.
     #
     # Error remains a RuntimeError so existing rescue handlers keep working.
-    # The `is_*` methods mirror predicates on the captured native `wreq::Error`.
-    # One error can match more than one predicate. Errors created by the binding
-    # itself return false for all of them.
+    # Its subclass records one error category. The `is_*` methods preserve every
+    # predicate reported by the native `wreq::Error`, so more than one can be
+    # true. For example, a request timeout raises TimeoutError while both
+    # `is_timeout` and `is_request` are true.
+    #
+    # A native kind such as BodyError, TlsError, or StatusError takes precedence
+    # over details found in its cause chain. Native request errors are then
+    # classified as connection reset, timeout, proxy connection, destination
+    # connection, or RequestError, in that order. Use the predicates when code
+    # needs every native classification. Errors created by the binding itself
+    # return false for all of them.
     #
     # @example Rescue any wreq-ruby runtime error
     #   begin
@@ -43,10 +51,16 @@ unless defined?(Wreq)
       def is_status
       end
 
+      # A request timeout uses TimeoutError even when this is also a connection
+      # or proxy connection error.
+      #
       # @return [Boolean] Whether the native error is related to a timeout
       def is_timeout
       end
 
+      # This may be true on connection and timeout subclasses because those
+      # errors occur while sending a request.
+      #
       # @return [Boolean] Whether the native error is related to a request
       def is_request
       end
@@ -124,9 +138,10 @@ unless defined?(Wreq)
 
     # Raised when the client cannot connect to the destination server.
     #
-    # The error reflects the layer that actually fails. If a system proxy or
-    # VPN accepts the connection but does not return a response, the request
-    # raises Wreq::TimeoutError instead.
+    # If the native error reports both a destination connection failure and a
+    # timeout, Wreq::TimeoutError is raised and `is_connect` remains true. A
+    # system proxy or VPN that accepts the connection but never responds may
+    # instead appear as a general request timeout.
     #
     # @example Handle a destination connection failure
     #   client = Wreq::Client.new(no_proxy: true)
@@ -138,6 +153,9 @@ unless defined?(Wreq)
     class ConnectionError < Error; end
 
     # Raised when the client cannot connect to the configured proxy.
+    #
+    # If the native error reports both a proxy connection failure and a timeout,
+    # Wreq::TimeoutError is raised and `is_proxy_connect` remains true.
     #
     # @example Handle a proxy connection failure
     #   begin
@@ -182,6 +200,11 @@ unless defined?(Wreq)
 
     # Raised for a request failure without a more specific error subclass.
     #
+    # Connection reset and timeout causes use their corresponding subclasses
+    # first. A reset takes precedence if both predicates are present. Other
+    # proxy and destination connection failures use their connection subclasses
+    # before this fallback.
+    #
     # @example Rescue the native fallback request category
     #   client = Wreq::Client.new
     #   begin
@@ -217,6 +240,11 @@ unless defined?(Wreq)
     class RedirectError < Error; end
 
     # Raised when a request operation exceeds its timeout.
+    #
+    # This includes destination and proxy connection timeouts when the native
+    # error reports them as timeouts. Check `is_connect` or `is_proxy_connect`
+    # to see whether the native error also identifies that phase. `is_request`
+    # can be true on the same error.
     #
     # @example Handle a request timeout
     #   client = Wreq::Client.new(timeout: 1)

--- a/src/error.rs
+++ b/src/error.rs
@@ -156,9 +156,9 @@ define_error_mapping! {
         => CONNECTION_RESET_ERROR("ConnectionResetError"),
     Timeout [RequestDetail]: is_timeout as timeout => TIMEOUT_ERROR("TimeoutError"),
     ProxyConnect [RequestDetail]:
-        is_proxy_connect as proxy_connection
-        => PROXY_CONNECTION_ERROR("ProxyConnectionError"),
-    Connect [RequestDetail]: is_connect as connection => CONNECTION_ERROR("ConnectionError"),
+        is_proxy_connect as proxy_connect
+        => PROXY_CONNECT_ERROR("ProxyConnectError"),
+    Connect [RequestDetail]: is_connect as connect => CONNECT_ERROR("ConnectError"),
 }
 
 /// Native predicates retained after consuming a wreq error.

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,20 +45,40 @@ macro_rules! initialize_exception {
 }
 
 macro_rules! define_error_mapping {
-    ($($predicate:ident: $method:ident => $class:ident $(($ruby_name:literal))?),+ $(,)?) => {
-        /// Native predicates ordered by Ruby exception class priority.
-        #[derive(Clone, Copy)]
+    (
+        $(
+            $predicate:ident [$role:ident]:
+                $method:ident => $class:ident $(($ruby_name:literal))?
+        ),+ $(,)?
+    ) => {
+        /// How a native predicate participates in Ruby exception classification.
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        enum ErrorPredicateRole {
+            NativeKind,
+            RequestDetail,
+        }
+
+        /// Predicates captured from a native `wreq::Error`.
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
         #[repr(u8)]
         enum ErrorPredicate {
             $($predicate),+
         }
 
         impl ErrorPredicate {
-            const CLASSIFICATION_ORDER: &'static [Self] = &[$(Self::$predicate),+];
+            /// Every predicate retained in Ruby exception metadata.
+            const ALL: &'static [Self] = &[$(Self::$predicate),+];
 
             /// Return this predicate's position in the compact Ruby metadata.
             const fn mask(self) -> u16 {
                 1_u16 << (self as u8)
+            }
+
+            /// Return whether this is a native kind or a request detail.
+            const fn role(self) -> ErrorPredicateRole {
+                match self {
+                    $(Self::$predicate => ErrorPredicateRole::$role,)+
+                }
             }
 
             /// Evaluate this predicate before the native error is consumed.
@@ -68,7 +88,7 @@ macro_rules! define_error_mapping {
                 }
             }
 
-            /// Return the Ruby class selected when this predicate has priority.
+            /// Return the Ruby class represented by this predicate.
             fn error_class(self) -> &'static Lazy<ExceptionClass> {
                 match self {
                     $(Self::$predicate => &$class,)+
@@ -76,8 +96,7 @@ macro_rules! define_error_mapping {
             }
         }
 
-        const _: () =
-            assert!(ErrorPredicate::CLASSIFICATION_ORDER.len() <= u16::BITS as usize);
+        const _: () = assert!(ErrorPredicate::ALL.len() <= u16::BITS as usize);
 
         $(
             $(define_exception!($class, $ruby_name, exception_runtime_error);)?
@@ -113,20 +132,24 @@ macro_rules! define_error_mapping {
     };
 }
 
-// The first matching entry determines the Ruby exception class.
+// wreq keeps its error kind private. Keep its mutually exclusive kind predicates
+// separate from request details, which inspect the source chain and may overlap.
+// Entries within each role are classified from top to bottom.
 define_error_mapping! {
-    Builder: is_builder => BUILDER_ERROR("BuilderError"),
-    Body: is_body => BODY_ERROR("BodyError"),
-    Tls: is_tls => TLS_ERROR("TlsError"),
-    ConnectionReset: is_connection_reset => CONNECTION_RESET_ERROR("ConnectionResetError"),
-    Connect: is_connect => CONNECTION_ERROR("ConnectionError"),
-    ProxyConnect: is_proxy_connect => PROXY_CONNECTION_ERROR("ProxyConnectionError"),
-    Decode: is_decode => DECODING_ERROR("DecodingError"),
-    Redirect: is_redirect => REDIRECT_ERROR("RedirectError"),
-    Timeout: is_timeout => TIMEOUT_ERROR("TimeoutError"),
-    Status: is_status => STATUS_ERROR("StatusError"),
-    Request: is_request => REQUEST_ERROR("RequestError"),
-    Upgrade: is_upgrade => WREQ_ERROR,
+    Builder [NativeKind]: is_builder => BUILDER_ERROR("BuilderError"),
+    Body [NativeKind]: is_body => BODY_ERROR("BodyError"),
+    Tls [NativeKind]: is_tls => TLS_ERROR("TlsError"),
+    Decode [NativeKind]: is_decode => DECODING_ERROR("DecodingError"),
+    Redirect [NativeKind]: is_redirect => REDIRECT_ERROR("RedirectError"),
+    Status [NativeKind]: is_status => STATUS_ERROR("StatusError"),
+    Upgrade [NativeKind]: is_upgrade => WREQ_ERROR,
+    Request [NativeKind]: is_request => REQUEST_ERROR("RequestError"),
+    ConnectionReset [RequestDetail]:
+        is_connection_reset => CONNECTION_RESET_ERROR("ConnectionResetError"),
+    Timeout [RequestDetail]: is_timeout => TIMEOUT_ERROR("TimeoutError"),
+    ProxyConnect [RequestDetail]:
+        is_proxy_connect => PROXY_CONNECTION_ERROR("ProxyConnectionError"),
+    Connect [RequestDetail]: is_connect => CONNECTION_ERROR("ConnectionError"),
 }
 
 /// Native predicates retained after consuming a wreq error.
@@ -157,12 +180,35 @@ impl ErrorPredicates {
         }
         self
     }
+
+    /// Select one Ruby exception class without treating all predicates as peers.
+    ///
+    /// Native kinds are mutually exclusive. Connection and timeout predicates
+    /// only refine the request kind because they inspect the error source chain.
+    fn classifying_predicate(self) -> Option<ErrorPredicate> {
+        let kind = ErrorPredicate::ALL.iter().copied().find(|predicate| {
+            predicate.role() == ErrorPredicateRole::NativeKind && self.contains(*predicate)
+        })?;
+
+        if kind == ErrorPredicate::Request {
+            ErrorPredicate::ALL
+                .iter()
+                .copied()
+                .find(|predicate| {
+                    predicate.role() == ErrorPredicateRole::RequestDetail
+                        && self.contains(*predicate)
+                })
+                .or(Some(kind))
+        } else {
+            Some(kind)
+        }
+    }
 }
 
 impl From<&wreq::Error> for ErrorPredicates {
     /// Snapshot every native predicate before consuming the wreq error.
     fn from(error: &wreq::Error) -> Self {
-        ErrorPredicate::CLASSIFICATION_ORDER
+        ErrorPredicate::ALL
             .iter()
             .copied()
             .fold(Self::default(), |predicates, predicate| {
@@ -327,13 +373,10 @@ pub fn type_error(ruby: &Ruby, message: impl Into<Cow<'static, str>>) -> MagnusE
 
 /// Select the most specific Ruby exception class for native predicates.
 fn wreq_error_class(ruby: &Ruby, predicates: ErrorPredicates) -> ExceptionClass {
-    for &predicate in ErrorPredicate::CLASSIFICATION_ORDER {
-        if predicates.contains(predicate) {
-            return ruby.get_inner(predicate.error_class());
-        }
-    }
-
-    ruby.get_inner(&WREQ_ERROR)
+    predicates.classifying_predicate().map_or_else(
+        || ruby.get_inner(&WREQ_ERROR),
+        |predicate| ruby.get_inner(predicate.error_class()),
+    )
 }
 
 /// Read one native predicate from a Ruby error, defaulting to false.
@@ -416,9 +459,18 @@ pub fn include(ruby: &Ruby, gem_module: &RModule) -> Result<(), MagnusError> {
 mod tests {
     use super::{ErrorPredicate, ErrorPredicates};
 
+    fn predicates(entries: &[ErrorPredicate]) -> ErrorPredicates {
+        entries
+            .iter()
+            .copied()
+            .fold(ErrorPredicates::default(), |predicates, predicate| {
+                predicates.include_if(predicate, true)
+            })
+    }
+
     #[test]
     fn error_predicate_bits_are_unique_and_round_trip() {
-        let predicates = ErrorPredicate::CLASSIFICATION_ORDER.iter().copied().fold(
+        let predicates = ErrorPredicate::ALL.iter().copied().fold(
             ErrorPredicates::default(),
             |predicates, predicate| {
                 assert!(!predicates.contains(predicate));
@@ -427,13 +479,74 @@ mod tests {
         );
 
         assert_eq!(
-            ErrorPredicate::CLASSIFICATION_ORDER.len(),
+            ErrorPredicate::ALL.len(),
             predicates.bits().count_ones() as usize
         );
 
         let restored = ErrorPredicates::from_bits(predicates.bits());
-        for &predicate in ErrorPredicate::CLASSIFICATION_ORDER {
+        for &predicate in ErrorPredicate::ALL {
             assert!(restored.contains(predicate));
+        }
+    }
+
+    #[test]
+    fn error_classification_separates_native_kinds_from_request_details() {
+        let cases: &[(&[ErrorPredicate], Option<ErrorPredicate>)] = &[
+            (&[], None),
+            (&[ErrorPredicate::Upgrade], Some(ErrorPredicate::Upgrade)),
+            (&[ErrorPredicate::Request], Some(ErrorPredicate::Request)),
+            (
+                &[ErrorPredicate::Request, ErrorPredicate::Connect],
+                Some(ErrorPredicate::Connect),
+            ),
+            (
+                &[ErrorPredicate::Request, ErrorPredicate::ProxyConnect],
+                Some(ErrorPredicate::ProxyConnect),
+            ),
+            (
+                &[ErrorPredicate::Request, ErrorPredicate::Timeout],
+                Some(ErrorPredicate::Timeout),
+            ),
+            (
+                &[
+                    ErrorPredicate::Request,
+                    ErrorPredicate::Connect,
+                    ErrorPredicate::Timeout,
+                ],
+                Some(ErrorPredicate::Timeout),
+            ),
+            (
+                &[
+                    ErrorPredicate::Request,
+                    ErrorPredicate::ProxyConnect,
+                    ErrorPredicate::Timeout,
+                ],
+                Some(ErrorPredicate::Timeout),
+            ),
+            (
+                &[
+                    ErrorPredicate::Request,
+                    ErrorPredicate::ConnectionReset,
+                    ErrorPredicate::Timeout,
+                ],
+                Some(ErrorPredicate::ConnectionReset),
+            ),
+            (
+                &[
+                    ErrorPredicate::Body,
+                    ErrorPredicate::Request,
+                    ErrorPredicate::Timeout,
+                ],
+                Some(ErrorPredicate::Body),
+            ),
+        ];
+
+        for &(entries, expected) in cases {
+            assert_eq!(
+                expected,
+                predicates(entries).classifying_predicate(),
+                "predicates: {entries:?}"
+            );
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,7 +49,8 @@ macro_rules! define_error_mapping {
     (
         $(
             $predicate:ident [$role:ident]:
-                $method:ident => $class:ident $(($ruby_name:literal))?
+                $native_method:ident as $ruby_method:ident
+                => $class:ident $(($ruby_name:literal))?
         ),+ $(,)?
     ) => {
         /// How a native predicate participates in Ruby exception classification.
@@ -85,7 +86,7 @@ macro_rules! define_error_mapping {
             /// Evaluate this predicate before the native error is consumed.
             fn matches_wreq(self, error: &wreq::Error) -> bool {
                 match self {
-                    $(Self::$predicate => error.$method(),)+
+                    $(Self::$predicate => error.$native_method(),)+
                 }
             }
 
@@ -105,15 +106,18 @@ macro_rules! define_error_mapping {
         )+
 
         $(
-            fn $method(rb_self: RObject) -> Result<bool, MagnusError> {
+            fn $native_method(rb_self: RObject) -> Result<bool, MagnusError> {
                 error_has_predicate(rb_self, ErrorPredicate::$predicate)
             }
         )+
 
-        /// Define the native wreq predicate methods on Wreq::Error.
+        /// Define idiomatic Ruby predicate methods on `Wreq::Error`.
         fn include_error_predicates(class: ExceptionClass) -> Result<(), MagnusError> {
             $(
-                class.define_method(stringify!($method), magnus::method!($method, 0))?;
+                class.define_method(
+                    concat!(stringify!($ruby_method), "?"),
+                    magnus::method!($native_method, 0),
+                )?;
             )+
             Ok(())
         }
@@ -136,22 +140,25 @@ macro_rules! define_error_mapping {
 
 // wreq keeps its error kind private. Keep its mutually exclusive kind predicates
 // separate from request details, which inspect the source chain and may overlap.
+// Each entry maps the native method before `as` to the Ruby predicate after it.
 // Entries within each role are classified from top to bottom.
 define_error_mapping! {
-    Builder [NativeKind]: is_builder => BUILDER_ERROR("BuilderError"),
-    Body [NativeKind]: is_body => BODY_ERROR("BodyError"),
-    Tls [NativeKind]: is_tls => TLS_ERROR("TlsError"),
-    Decode [NativeKind]: is_decode => DECODING_ERROR("DecodingError"),
-    Redirect [NativeKind]: is_redirect => REDIRECT_ERROR("RedirectError"),
-    Status [NativeKind]: is_status => STATUS_ERROR("StatusError"),
-    Upgrade [NativeKind]: is_upgrade => WREQ_ERROR,
-    Request [NativeKind]: is_request => REQUEST_ERROR("RequestError"),
+    Builder [NativeKind]: is_builder as builder => BUILDER_ERROR("BuilderError"),
+    Body [NativeKind]: is_body as body => BODY_ERROR("BodyError"),
+    Tls [NativeKind]: is_tls as tls => TLS_ERROR("TlsError"),
+    Decode [NativeKind]: is_decode as decoding => DECODING_ERROR("DecodingError"),
+    Redirect [NativeKind]: is_redirect as redirect => REDIRECT_ERROR("RedirectError"),
+    Status [NativeKind]: is_status as status => STATUS_ERROR("StatusError"),
+    Upgrade [NativeKind]: is_upgrade as upgrade => WREQ_ERROR,
+    Request [NativeKind]: is_request as request => REQUEST_ERROR("RequestError"),
     ConnectionReset [RequestDetail]:
-        is_connection_reset => CONNECTION_RESET_ERROR("ConnectionResetError"),
-    Timeout [RequestDetail]: is_timeout => TIMEOUT_ERROR("TimeoutError"),
+        is_connection_reset as connection_reset
+        => CONNECTION_RESET_ERROR("ConnectionResetError"),
+    Timeout [RequestDetail]: is_timeout as timeout => TIMEOUT_ERROR("TimeoutError"),
     ProxyConnect [RequestDetail]:
-        is_proxy_connect => PROXY_CONNECTION_ERROR("ProxyConnectionError"),
-    Connect [RequestDetail]: is_connect => CONNECTION_ERROR("ConnectionError"),
+        is_proxy_connect as proxy_connection
+        => PROXY_CONNECTION_ERROR("ProxyConnectionError"),
+    Connect [RequestDetail]: is_connect as connection => CONNECTION_ERROR("ConnectionError"),
 }
 
 /// Native predicates retained after consuming a wreq error.

--- a/test/error_handling_test.rb
+++ b/test/error_handling_test.rb
@@ -32,13 +32,12 @@ class ErrorHandlingTest < Minitest::Test
     request_thread&.join(1)
   end
 
-  def test_network_error_handling
-    # Try to connect to a non-existent domain
+  def test_connect_error_handling
+    # wreq classifies DNS failures as connect errors.
     response = Wreq.get("https://definitely-not-a-real-domain-12345.com")
     flunk "Expected network error but got response: #{response.code}"
   rescue => e
-    assert_instance_of Wreq::ConnectionError, e
-    # Network errors should be caught and wrapped appropriately
+    assert_instance_of Wreq::ConnectError, e
   end
 
   def test_invalid_url_handling
@@ -97,7 +96,7 @@ class ErrorHandlingTest < Minitest::Test
     end
   end
 
-  def test_proxy_error_handling
+  def test_proxy_connect_error_handling
     invalid_proxies = [
       "http://invalid.proxy:8080",
       "https://invalid.proxy:8080",
@@ -111,11 +110,11 @@ class ErrorHandlingTest < Minitest::Test
     invalid_proxies.each do |proxy|
       target_urls.each do |url|
         Wreq.get(url, proxy: proxy, timeout: 5)
-        flunk "Expected proxy connection error but got response"
+        flunk "Expected proxy connect error but got response"
       rescue => e
         assert(
-          e.is_a?(Wreq::ProxyConnectionError) || e.is_a?(Wreq::RequestError),
-          "Expected ProxyConnectionError or RequestError, got #{e.class}: #{e.message}"
+          e.is_a?(Wreq::ProxyConnectError) || e.is_a?(Wreq::RequestError),
+          "Expected ProxyConnectError or RequestError, got #{e.class}: #{e.message}"
         )
       end
     end

--- a/test/error_hierarchy_test.rb
+++ b/test/error_hierarchy_test.rb
@@ -19,18 +19,18 @@ class ErrorHierarchyTest < Minitest::Test
     BuilderError
   ].freeze
   NATIVE_ERROR_PREDICATES = %i[
-    is_builder
-    is_redirect
-    is_status
-    is_timeout
-    is_request
-    is_connect
-    is_proxy_connect
-    is_connection_reset
-    is_body
-    is_tls
-    is_decode
-    is_upgrade
+    builder?
+    redirect?
+    status?
+    timeout?
+    request?
+    connection?
+    proxy_connection?
+    connection_reset?
+    body?
+    tls?
+    decoding?
+    upgrade?
   ].freeze
 
   def test_regular_errors_share_stable_root
@@ -57,9 +57,9 @@ class ErrorHierarchyTest < Minitest::Test
     end
 
     assert_instance_of Wreq::BuilderError, root_error
-    assert root_error.is_builder
+    assert_predicate root_error, :builder?
     assert_nil root_error.status
-    assert_equal [:is_builder], active_native_predicates(root_error)
+    assert_equal [:builder?], active_native_predicates(root_error)
     assert_raises(Wreq::BuilderError) { Wreq.get("not-a-valid-url") }
   end
 
@@ -75,9 +75,9 @@ class ErrorHierarchyTest < Minitest::Test
     with_hanging_server do |url, _accepted|
       error = assert_raises(Wreq::TimeoutError) { client.get(url, timeout: 1) }
 
-      assert error.is_timeout
-      assert error.is_request
-      assert_equal %i[is_timeout is_request], active_native_predicates(error)
+      assert_predicate error, :timeout?
+      assert_predicate error, :request?
+      assert_equal %i[timeout? request?], active_native_predicates(error)
     end
   end
 
@@ -137,8 +137,8 @@ class ErrorHierarchyTest < Minitest::Test
         assert_equal status, error.status
         assert_equal response.url, error.uri
         assert_predicate error.uri, :frozen?
-        assert error.is_status
-        assert_equal [:is_status], active_native_predicates(error)
+        assert_predicate error, :status?
+        assert_equal [:status?], active_native_predicates(error)
         refute_respond_to error, :kind
         refute_respond_to error, :retryable?
         refute_includes error.message, "response-secret"
@@ -203,7 +203,7 @@ class ErrorHierarchyTest < Minitest::Test
     error = assert_raises(Wreq::BuilderError) { Wreq::Client.new(proxy: "://") }
 
     assert_includes error.message, ":proxy"
-    assert_equal [:is_builder], active_native_predicates(error)
+    assert_equal [:builder?], active_native_predicates(error)
   end
 
   private

--- a/test/error_hierarchy_test.rb
+++ b/test/error_hierarchy_test.rb
@@ -70,11 +70,14 @@ class ErrorHierarchyTest < Minitest::Test
   end
 
   def test_native_error_predicates_are_not_mutually_exclusive
+    client = Wreq::Client.new(no_proxy: true)
+
     with_hanging_server do |url, _accepted|
-      error = assert_raises(Wreq::TimeoutError) { Wreq.get(url, timeout: 1) }
+      error = assert_raises(Wreq::TimeoutError) { client.get(url, timeout: 1) }
 
       assert error.is_timeout
       assert error.is_request
+      assert_equal %i[is_timeout is_request], active_native_predicates(error)
     end
   end
 

--- a/test/error_hierarchy_test.rb
+++ b/test/error_hierarchy_test.rb
@@ -6,8 +6,8 @@ class ErrorHierarchyTest < Minitest::Test
   REGULAR_ERROR_NAMES = %i[
     MemoryError
     ForkError
-    ConnectionError
-    ProxyConnectionError
+    ConnectError
+    ProxyConnectError
     ConnectionResetError
     TlsError
     RequestError
@@ -24,8 +24,8 @@ class ErrorHierarchyTest < Minitest::Test
     status?
     timeout?
     request?
-    connection?
-    proxy_connection?
+    connect?
+    proxy_connect?
     connection_reset?
     body?
     tls?
@@ -40,10 +40,14 @@ class ErrorHierarchyTest < Minitest::Test
     REGULAR_ERROR_NAMES.each do |name|
       assert_equal Wreq::Error, Wreq.const_get(name).superclass
     end
+    refute Wreq.const_defined?(:ConnectionError, false)
+    refute Wreq.const_defined?(:ProxyConnectionError, false)
 
     error = Wreq::MemoryError.new
     assert_nil error.uri
     assert_nil error.status
+    refute_respond_to error, :connection?
+    refute_respond_to error, :proxy_connection?
     NATIVE_ERROR_PREDICATES.each do |predicate|
       assert_equal false, error.public_send(predicate)
     end


### PR DESCRIPTION
This PR makes Ruby exception selection deterministic when a wreq error reports overlapping native details. Native error kinds keep their own class. Request errors use this priority: connection reset, timeout, proxy connect, then connect. Every matching detail remains available through predicate methods.

This is a breaking change. The public names now follow wreq's connect-stage terminology:

- `Wreq::ConnectionError` becomes `Wreq::ConnectError`
- `Wreq::ProxyConnectionError` becomes `Wreq::ProxyConnectError`
- `connection?` becomes `connect?`
- `proxy_connection?` becomes `proxy_connect?`

`ConnectionResetError` and `connection_reset?` keep their names because they describe a reset event rather than the connect phase. The old names are removed, so callers need to update rescue clauses and predicate checks.

The Ruby API docs now explain connect, proxy connect, timeout, and reset overlap. The complete Ruby and Rust test suites, Clippy, Rustfmt, and StandardRB pass on Windows GNU.